### PR TITLE
concatenate Dockerfile commands - reduces final images size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM netroby/alpine-php
 
-RUN wget https://www.phpmyadmin.net/downloads/phpMyAdmin-latest-all-languages.tar.gz
-RUN tar xzf phpMyAdmin*.tar.gz
-RUN rm phpMyAdmin*.tar.gz
-RUN mv phpMyAdmin* /www
+RUN wget https://www.phpmyadmin.net/downloads/phpMyAdmin-latest-all-languages.tar.gz \
+ && tar xzf phpMyAdmin*.tar.gz \
+ && rm phpMyAdmin*.tar.gz \
+ && mv phpMyAdmin* /www
 
 COPY config.inc.php /www/config.inc.php
 


### PR DESCRIPTION
Hi,

this patch reduces final image size from 99 MiB to 57 MiB