### PR TITLE
fix for: add support for arbitrary servers and compose configuration file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 phpmyadmin:
-    image: phpmyadmin:testing
+    image: phpmyadmin/phpmyadmin
     container_name: myadmin
     environment:
      - PMA_ARBITRARY=1


### PR DESCRIPTION
With arbitrary server you can also manage non-dockerized or remote databases.

With docker-compose configuration you can more easily manage your phpMyAdmin container.

Fix: image source in docker-compose.yml - use official image from registry instead of local build