### PR TITLE
Allows to set the user-facing URL, fixes #12

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ Using the docker-compose.yml from https://github.com/phpmyadmin/docker
 docker-compose up -d
 ```
 
+## Usage behind reverse proxys
+Set the variable ``PMA_ABSOLUTE_URI`` to the fully-qualified path (``https://pma.example.net/``) where the reverse proxy makes phpMyAdmin available.
+
 ## Environment variables summary
 
 * ``PMA_ARBITRARY`` - when set to 1 connection to the arbitrary server will be allowed
@@ -52,3 +55,4 @@ docker-compose up -d
 * ``PMA_PORT`` - define port of the MySQL server
 * ``PMA_HOSTS`` - define comma separated list of address/host names of the MySQL servers
 * ``PMA_USER`` and ``PMA_PASSWORD`` - define username to use for config authentication method
+* ``PMA_ABSOLUTE_URI`` - define user-facing URI

--- a/config.inc.php
+++ b/config.inc.php
@@ -10,6 +10,7 @@ $vars = array(
     'PMA_PORT',
     'PMA_USER',
     'PMA_PASSWORD',
+    'PMA_ABSOLUTE_URI'
 );
 foreach ($vars as $var) {
     if (!isset($_ENV[$var]) && getenv($var)) {

--- a/config.inc.php
+++ b/config.inc.php
@@ -22,6 +22,11 @@ if (isset($_ENV['PMA_ARBITRARY']) && $_ENV['PMA_ARBITRARY'] === '1') {
     $cfg['AllowArbitraryServer'] = true;
 }
 
+/* Play nice behind reverse proxys */
+if (isset($_ENV['PMA_ABSOLUTE_URI'])) {
+    $cfg['PmaAbsoluteUri'] = trim($_ENV['PMA_ABSOLUTE_URI']);
+}
+
 /* Figure out hosts */
 
 /* Fallback to default linked */


### PR DESCRIPTION
This PR allows users to set the user-facing URL (`PmaAbsoluteUri`) to facilitate usage behind reverse proxies.