### PR TITLE
Make php server PID 1

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -8,4 +8,4 @@ if [ ! -f /www/config.secret.inc.php ] ; then
 EOT
 fi
 
-php -S 0.0.0.0:8080 -t /www/
+exec php -S 0.0.0.0:8080 -t /www/


### PR DESCRIPTION
It's a good practice to make the service PID 1
(although php cli does not handle `kill -TERM` at all).