### PR TITLE
Improve apk usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM alpine
 
-RUN apk add --update php-cli php-mysqli php-ctype php-xml php-gd php-zlib php-openssl php-curl php-opcache php-json curl \
- && rm -rf /var/cache/apk/*
+RUN apk add --no-cache php-cli php-mysqli php-ctype php-xml php-gd php-zlib php-openssl php-curl php-opcache php-json curl
 
 RUN curl --location https://www.phpmyadmin.net/downloads/phpMyAdmin-latest-all-languages.tar.gz | tar xzf - \
  && mv phpMyAdmin* /www \


### PR DESCRIPTION
`--no-cache` will avoid cache usage and do an automatic update.

Cache directory deletion is not necessary anymore.