### PR TITLE
Increase "max_input_vars" value

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN chmod u+rwx /run.sh
 RUN sed -i \
     -e "s/^upload_max_filesize\s*=\s*2M/upload_max_filesize = 64M/" \
     -e "s/^post_max_size\s*=\s*8M/post_max_size = 64M/" \
+    -e "s/^;\s*max_input_vars\s*=\s*1000/max_input_vars = 2000/" \
     /etc/php/php.ini
 
 EXPOSE 8080


### PR DESCRIPTION
To allow exporting databases with many tables (e.g. Prestashop CMS)