### PR TITLE
Switch to port 80 (instead of 8080)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,17 +15,17 @@ script:
   # Build image
   - docker build -t phpmyadmin/phpmyadmin .
   # Test for single database
-  - docker run --name testadmin -d --link db_server:db -p 9090:8080 phpmyadmin/phpmyadmin
+  - docker run --name testadmin -d --link db_server:db -p 9090:80 phpmyadmin/phpmyadmin
   - docker ps -a
   - curl http://127.0.0.1:9090/ | grep -q input_password
   - curl --cookie-jar /tmp/cj --location -d pma_username=root -d pma_password=my-secret-pw -d server=1 http://127.0.0.1:9090/ | grep -r 'db via TCP'
   # Test for single database using env
-  - docker run --name envadmin -d --link db_server:db2 -e PMA_HOST=db2 -p 6060:8080 phpmyadmin/phpmyadmin
+  - docker run --name envadmin -d --link db_server:db2 -e PMA_HOST=db2 -p 6060:80 phpmyadmin/phpmyadmin
   - docker ps -a
   - curl http://127.0.0.1:6060/ | grep -q input_password
   - curl --cookie-jar /tmp/cj --location -d pma_username=root -d pma_password=my-secret-pw -d server=1 http://127.0.0.1:6060/ | grep -r 'db2 via TCP'
   # Test for arbitrary database
-  - docker run --name arbitraryadmin -d --link db_server:db -e PMA_ARBITRARY=1 -p 7070:8080 phpmyadmin/phpmyadmin
+  - docker run --name arbitraryadmin -d --link db_server:db -e PMA_ARBITRARY=1 -p 7070:80 phpmyadmin/phpmyadmin
   - docker ps -a
   - curl http://127.0.0.1:7070/ | grep -q input_password
   - curl --cookie-jar /tmp/cj --location -d pma_servername=db -d pma_username=root -d pma_password=my-secret-pw -d server=1 http://127.0.0.1:7070/ | grep -r 'db via TCP'

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,6 @@ RUN sed -i \
     -e "s/^;\s*max_input_vars\s*=\s*1000/max_input_vars = 2000/" \
     /etc/php/php.ini
 
-EXPOSE 8080
+EXPOSE 80
 
 ENTRYPOINT [ "/run.sh" ]

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ First you need to run MySQL or MariaDB server in Docker, and this image need
 link a running mysql instance container:
 
 ```
-docker run --name myadmin -d --link mysql_db_server:db -p 8080:8080 phpmyadmin/phpmyadmin
+docker run --name myadmin -d --link mysql_db_server:db -p 8080:80 phpmyadmin/phpmyadmin
 ```
 
 ## Usage with external server
@@ -23,7 +23,7 @@ You can specify MySQL host in the `PMA_HOST` environment variable. You can also
 use `PMA_PORT` to specify port of the server in case it's not the default one:
 
 ```
-docker run --name myadmin -d -e PMA_HOST=dbhost -p 8080:8080 phpmyadmin/phpmyadmin
+docker run --name myadmin -d -e PMA_HOST=dbhost -p 8080:80 phpmyadmin/phpmyadmin
 ```
 
 ## Usage with arbitrary server
@@ -31,7 +31,7 @@ docker run --name myadmin -d -e PMA_HOST=dbhost -p 8080:8080 phpmyadmin/phpmyadm
 You can use arbitrary servers by adding ENV variable `PMA_ARBITRARY=1` to the startup command:
 
 ```
-docker run --name myadmin -d --link mysql_db_server:db -p 8080:8080 -e PMA_ARBITRARY=1 phpmyadmin/phpmyadmin
+docker run --name myadmin -d --link mysql_db_server:db -p 8080:80 -e PMA_ARBITRARY=1 phpmyadmin/phpmyadmin
 ```
 
 ## Usage with docker-compose and arbitrary server

--- a/docker-compose.testing.yml
+++ b/docker-compose.testing.yml
@@ -5,4 +5,4 @@ phpmyadmin:
      - PMA_ARBITRARY=1
     restart: always
     ports:
-     - 8090:8080
+     - 8090:80

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,4 +5,4 @@ phpmyadmin:
      - PMA_ARBITRARY=1
     restart: always
     ports:
-     - 8080:8080
+     - 8080:80

--- a/run.sh
+++ b/run.sh
@@ -8,4 +8,4 @@ if [ ! -f /www/config.secret.inc.php ] ; then
 EOT
 fi
 
-exec php -S 0.0.0.0:8080 -t /www/
+exec php -S 0.0.0.0:80 -t /www/


### PR DESCRIPTION
As this is a Docker container running a web application, it would make sense to expose the http port (80) instead of port 8080. A user can always specify the 'external' port to his liking using e.g. `-p 8080:80`.

This PR changes the container itself as well as all references from tests and documentation.

Fixes #18.