### PR TITLE
Update base image to alpine:latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-# Switch back to stable once 3.4 is out
-FROM alpine:edge
+FROM alpine:latest
 
 RUN apk add --no-cache php5-cli php5-mysqli php5-ctype php5-xml php5-gd php5-zlib php5-bz2 php5-zip php5-openssl php5-curl php5-opcache php5-json php5-mcrypt curl
 


### PR DESCRIPTION
As per note in previous version of Dockerfile to switch to stable when 3.4 was out; it is.

Also removed comment since it's done.