### PR TITLE
config.userdef.inc.php hook to allow user configured settings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,24 @@ Using the docker-compose.yml from https://github.com/phpmyadmin/docker
 docker-compose up -d
 ```
 
+## Adding Custom Configuration
+
+You can add your own custom config.inc.php settings (such as Configuration Storage setup) 
+by creating a file named "config.userdef.inc.php" with the various user defined settings
+in it, and then linking it into the container using:
+
+```
+-v /some/local/directory/config.userdef.inc.php:/www/config.userdef.inc.php
+```
+On the "docker run" line like this:
+``` 
+docker run --name myadmin -d --link mysql_db_server:db -p 8080:80 -v /some/local/directory/config.userdef.inc.php:/www/config.userdef.inc.php phpmyadmin/phpmyadmin
+```
+
+See the following links for config file information.
+http://docs.phpmyadmin.net/en/latest/config.html#config
+http://docs.phpmyadmin.net/en/latest/setup.html
+
 ## Environment variables summary
 
 * ``PMA_ARBITRARY`` - when set to 1 connection to the arbitrary server will be allowed

--- a/config.inc.php
+++ b/config.inc.php
@@ -55,3 +55,7 @@ for ($i = 1; isset($hosts[$i - 1]); $i++) {
 /* Uploads setup */
 $cfg['UploadDir'] = '';
 $cfg['SaveDir'] = '';
+
+/* Include User Defined Settings Hook */
+include('./config.userdef.inc.php');
+

--- a/run.sh
+++ b/run.sh
@@ -8,6 +8,10 @@ if [ ! -f /www/config.secret.inc.php ] ; then
 EOT
 fi
 
+if [ ! -f /www/config.userdef.inc.php ] ; then
+  touch /www/config.userdef.inc.php
+fi
+
 exec php -S 0.0.0.0:80 -t /www/ \
     -d upload_max_filesize=$PHP_UPLOAD_MAX_FILESIZE \
     -d post_max_size=$PHP_UPLOAD_MAX_FILESIZE \


### PR DESCRIPTION
Added a hook to config.inc.php allowing for users to update PHPMYADMIN / config.inc.php settings as can be done in the non-docker version of phpmyadmin.  This allows users to create custom file called "config.userdef.inc.php" which when linked into the container will allow modification of the normal phpmyadmin config settings.

Updated:
config.inc.php - Included the hook at the end of the file.
run.sh - created a blank config.userdef.inc.php file so as to avoid the warnings generated by including a non-existent file in PHP.
README.md - Updated documentation to identify the ability to create the config.userdef.inc.php and how to link it to the container.