### PR TITLE
Adding PMA_VERBOSE and PMA_VERBOSES environment variables

### DIFF
--- a/config.inc.php
+++ b/config.inc.php
@@ -7,6 +7,8 @@ $vars = array(
     'PMA_ARBITRARY',
     'PMA_HOST',
     'PMA_HOSTS',
+    'PMA_VERBOSE',
+    'PMA_VERBOSES',
     'PMA_PORT',
     'PMA_USER',
     'PMA_PASSWORD',
@@ -71,4 +73,3 @@ $cfg['SaveDir'] = '';
 if (file_exists('/config.user.inc.php')) {
     include('/config.user.inc.php');
 }
-


### PR DESCRIPTION
It fix an issue with PMA_VERBOSE and PMA_VERBOSES environment variables when selecting a mysql server.

Thank you