### PR TITLE
Optimize PHP opcache settings

### DIFF
--- a/etc/php.ini
+++ b/etc/php.ini
@@ -1857,7 +1857,7 @@ opcache.enable=1
 
 ; When disabled, you must reset the OPcache manually or restart the
 ; webserver for changes to the filesystem to take effect.
-;opcache.validate_timestamps=1
+opcache.validate_timestamps=0
 
 ; How often (in seconds) to check file timestamps for changes to the shared
 ; memory storage allocation. ("1" means validate once per second, but only
@@ -1869,7 +1869,7 @@ opcache.enable=1
 
 ; If disabled, all PHPDoc comments are dropped from the code to reduce the
 ; size of the optimized code.
-;opcache.save_comments=1
+opcache.save_comments=0
 
 ; If disabled, PHPDoc comments are not loaded from SHM, so "Doc Comments"
 ; may be always stored (save_comments=1), but not loaded by applications


### PR DESCRIPTION
- opcache.save_comments=0 to avoid storing comments which we do not need
- opcache.validate_timestamps=0 the timestamps validation should not be
  needed as container is restarted on change
- fixes #71

Signed-off-by: Michal Čihař <michal@cihar.com>