### PR TITLE
Cancel removal of /www/sql

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN set -x \
     && tar xzf phpMyAdmin.tar.gz \
     && rm -f phpMyAdmin.tar.gz phpMyAdmin.tar.gz.asc \
     && mv phpMyAdmin-$VERSION-all-languages /www \
-    && rm -rf /www/js/jquery/src/ /www/js/openlayers/src/ /www/setup/ /www/sql/ /www/examples/ /www/test/ /www/po/ /www/templates/test/ /www/phpunit.xml.* /www/build.xml  /www/composer.json /www/RELEASE-DATE-$VERSION \
+    && rm -rf /www/js/jquery/src/ /www/js/openlayers/src/ /www/setup/ /www/examples/ /www/test/ /www/po/ /www/templates/test/ /www/phpunit.xml.* /www/build.xml  /www/composer.json /www/RELEASE-DATE-$VERSION \
     && chown -R root:nobody /www \
     && find /www -type d -exec chmod 750 {} \; \
     && find /www -type f -exec chmod 640 {} \;


### PR DESCRIPTION
Please do not delete /www/sql folder as it contains create_tables.sql file that creates pma tables and phpmyadmin db for configuration storage