### PR TITLE
Cleanup documentation folder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,10 @@ RUN set -x \
     && tar xzf phpMyAdmin.tar.gz \
     && rm -f phpMyAdmin.tar.gz phpMyAdmin.tar.gz.asc \
     && mv phpMyAdmin-$VERSION-all-languages /www \
+    && mv /www/doc/html /www/htmldoc \
+    && rm -rf /www/doc \
+    && mkdir /www/doc \
+    && mv /www/htmldoc /www/doc/html \
     && rm -rf /www/js/jquery/src/ /www/js/openlayers/src/ /www/setup/ /www/examples/ /www/test/ /www/po/ /www/templates/test/ /www/phpunit.xml.* /www/build.xml  /www/composer.json /www/RELEASE-DATE-$VERSION \
     && chown -R root:nobody /www \
     && find /www -type d -exec chmod 750 {} \; \


### PR DESCRIPTION
We really do not need documentation source in the Docker image.

Fixes #79

Signed-off-by: Michal Čihař <michal@cihar.com>