### PR TITLE
Update docker-compose test environment based on CI's tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.5
 
 # Install dependencies
-RUN apk add --no-cache php7-session php7-mysqli php7-mbstring php7-xml php7-gd php7-zlib php7-bz2 php7-zip php7-openssl php7-curl php7-opcache php7-json nginx php7-fpm supervisor
+RUN apk add --no-cache curl php7-session php7-mysqli php7-mbstring php7-xml php7-gd php7-zlib php7-bz2 php7-zip php7-openssl php7-curl php7-opcache php7-json nginx php7-fpm py2-pip supervisor
 
 # Include keyring to verify download
 COPY phpmyadmin.keyring /
@@ -22,11 +22,11 @@ LABEL version=$VERSION
 RUN set -x \
     && GNUPGHOME="$(mktemp -d)" \
     && export GNUPGHOME \
-    && apk add --no-cache curl gnupg \
+    && apk add --no-cache gnupg \
     && curl --output phpMyAdmin.tar.gz --location $URL \
     && curl --output phpMyAdmin.tar.gz.asc --location $URL.asc \
     && gpgv --keyring /phpmyadmin.keyring phpMyAdmin.tar.gz.asc phpMyAdmin.tar.gz \
-    && apk del --no-cache curl gnupg \
+    && apk del --no-cache gnupg \
     && rm -rf "$GNUPGHOME" \
     && tar xzf phpMyAdmin.tar.gz \
     && rm -f phpMyAdmin.tar.gz phpMyAdmin.tar.gz.asc \

--- a/README.md
+++ b/README.md
@@ -67,6 +67,16 @@ Using the docker-compose.yml from https://github.com/phpmyadmin/docker
 docker-compose up -d
 ```
 
+## Run the E2E tests with docker-compose
+
+You can run the E2E tests with the local test environment by running MariaDB/MySQL databases. Adding ENV variable `PHPMYADMIN_RUN_TEST=true` already added on docker-compose file. Simply run:
+
+Using the docker-compose.testing.yml from https://github.com/phpmyadmin/docker
+
+```
+docker-compose -f docker-compose.testing.yml up phpmyadmin
+```
+
 ## Adding Custom Configuration
 
 You can add your own custom config.inc.php settings (such as Configuration Storage setup) 

--- a/docker-compose.testing.yml
+++ b/docker-compose.testing.yml
@@ -4,16 +4,12 @@ services:
   mariadb:
     image: mariadb:10.1
     container_name: phpmyadmin_testing_mariadb
-    volumes:
-      - ./world.sql:/docker-entrypoint-initdb.d/world.sql
     environment:
       - MYSQL_ROOT_PASSWORD=test123
 
   mysql:
     image: mysql:5.7
     container_name: phpmyadmin_testing_mysql
-    volumes:
-      - ./world.sql:/docker-entrypoint-initdb.d/world.sql
     environment:
       - MYSQL_ROOT_PASSWORD=test123
 
@@ -23,11 +19,16 @@ services:
       dockerfile: Dockerfile
     container_name: phpmyadmin_testing
     volumes:
+      - ./phpmyadmin_test.py:/phpmyadmin_test.py
+      - ./test-docker.sh:/test-docker.sh
+      - ./world.sql:/world.sql
       - /sessions
     ports:
       - 8090:80
     environment:
       - PMA_ARBITRARY=1
+      - PHPMYADMIN_RUN_TEST=true
+      - TESTSUITE_PASSWORD=test123
     depends_on:
       - mariadb
       - mysql

--- a/docker-compose.testing.yml
+++ b/docker-compose.testing.yml
@@ -1,8 +1,33 @@
-phpmyadmin:
-    image: phpmyadmin/phpmyadmin:testing
-    container_name: myadmin
+version: '2'
+
+services:
+  mariadb:
+    image: mariadb:10.1
+    container_name: phpmyadmin_testing_mariadb
+    volumes:
+      - ./world.sql:/docker-entrypoint-initdb.d/world.sql
     environment:
-     - PMA_ARBITRARY=1
-    restart: always
+      - MYSQL_ROOT_PASSWORD=test123
+
+  mysql:
+    image: mysql:5.7
+    container_name: phpmyadmin_testing_mysql
+    volumes:
+      - ./world.sql:/docker-entrypoint-initdb.d/world.sql
+    environment:
+      - MYSQL_ROOT_PASSWORD=test123
+
+  phpmyadmin:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: phpmyadmin_testing
+    volumes:
+      - /sessions
     ports:
-     - 8090:80
+      - 8090:80
+    environment:
+      - PMA_ARBITRARY=1
+    depends_on:
+      - mariadb
+      - mysql

--- a/etc/supervisor.d/test-mariadb.ini
+++ b/etc/supervisor.d/test-mariadb.ini
@@ -1,0 +1,12 @@
+[program:test-mariadb]
+command=/test-docker.sh test 80 mariadb
+autostart=true
+autorestart=false
+priority=3
+startretries=1
+stopwaitsecs=20
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+

--- a/etc/supervisor.d/test-mysql.ini
+++ b/etc/supervisor.d/test-mysql.ini
@@ -1,0 +1,12 @@
+[program:test-mysql]
+command=/test-docker.sh test 80 mysql
+autostart=true
+autorestart=false
+priority=3
+startretries=1
+stopwaitsecs=20
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+

--- a/etc/supervisord.conf
+++ b/etc/supervisord.conf
@@ -1,0 +1,131 @@
+; Sample supervisor config file.
+
+[unix_http_server]
+file=/run/supervisord.sock   ; (the path to the socket file)
+;chmod=0700                  ; socked file mode (default 0700)
+;chown=nobody:nogroup        ; socket file uid:gid owner
+;username=user               ; (default is no username (open server))
+;password=123                ; (default is no password (open server))
+
+;[inet_http_server]          ; inet (TCP) server disabled by default
+;port=127.0.0.1:9001         ; (ip_address:port specifier, *:port for all iface)
+;username=user               ; (default is no username (open server))
+;password=123                ; (default is no password (open server))
+
+[supervisord]
+logfile=/var/log/supervisord.log ; (main log file;default $CWD/supervisord.log)
+;logfile_maxbytes=50MB       ; (max main logfile bytes b4 rotation;default 50MB)
+;logfile_backups=10          ; (num of main logfile rotation backups;default 10)
+loglevel=info                ; (log level;default info; others: debug,warn,trace)
+;pidfile=/run/supervisord.pid ; (supervisord pidfile;default supervisord.pid)
+;nodaemon=false              ; (start in foreground if true;default false)
+;minfds=1024                 ; (min. avail startup file descriptors;default 1024)
+;minprocs=200                ; (min. avail process descriptors;default 200)
+;umask=022                   ; (process file creation umask;default 022)
+;user=chrism                 ; (default is current user, required if root)
+;identifier=supervisor       ; (supervisord identifier, default is 'supervisor')
+;directory=/tmp              ; (default is not to cd during start)
+;nocleanup=true              ; (don't clean up tempfiles at start;default false)
+;childlogdir=/var/log/supervisor ; ('AUTO' child log dir, default $TEMP)
+;environment=KEY=value       ; (key value pairs to add to environment)
+;strip_ansi=false            ; (strip ansi escape codes in logs; def. false)
+
+; the below section must remain in the config file for RPC
+; (supervisorctl/web interface) to work, additional interfaces may be
+; added by defining them in separate rpcinterface: sections
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+serverurl=unix:///run/supervisord.sock ; use a unix:// URL  for a unix socket
+;serverurl=http://127.0.0.1:9001 ; use an http:// url to specify an inet socket
+;username=chris              ; should be same as http_username if set
+;password=123                ; should be same as http_password if set
+;prompt=mysupervisor         ; cmd line prompt (default "supervisor")
+;history_file=~/.sc_history  ; use readline history if available
+
+; The below sample program section shows all possible program subsection values,
+; create one or more 'real' program: sections to be able to control them under
+; supervisor.
+
+;[program:theprogramname]
+;command=/bin/cat              ; the program (relative uses PATH, can take args)
+;process_name=%(program_name)s ; process_name expr (default %(program_name)s)
+;numprocs=1                    ; number of processes copies to start (def 1)
+;directory=/tmp                ; directory to cwd to before exec (def no cwd)
+;umask=022                     ; umask for process (default None)
+;priority=999                  ; the relative start priority (default 999)
+;autostart=true                ; start at supervisord start (default: true)
+;autorestart=unexpected        ; whether/when to restart (default: unexpected)
+;startsecs=1                   ; number of secs prog must stay running (def. 1)
+;startretries=3                ; max # of serial start failures (default 3)
+;exitcodes=0,2                 ; 'expected' exit codes for process (default 0,2)
+;stopsignal=QUIT               ; signal used to kill process (default TERM)
+;stopwaitsecs=10               ; max num secs to wait b4 SIGKILL (default 10)
+;killasgroup=false             ; SIGKILL the UNIX process group (def false)
+;user=chrism                   ; setuid to this UNIX account to run the program
+;redirect_stderr=true          ; redirect proc stderr to stdout (default false)
+;stdout_logfile=/a/path        ; stdout log path, NONE for none; default AUTO
+;stdout_logfile_maxbytes=1MB   ; max # logfile bytes b4 rotation (default 50MB)
+;stdout_logfile_backups=10     ; # of stdout logfile backups (default 10)
+;stdout_capture_maxbytes=1MB   ; number of bytes in 'capturemode' (default 0)
+;stdout_events_enabled=false   ; emit events on stdout writes (default false)
+;stderr_logfile=/a/path        ; stderr log path, NONE for none; default AUTO
+;stderr_logfile_maxbytes=1MB   ; max # logfile bytes b4 rotation (default 50MB)
+;stderr_logfile_backups=10     ; # of stderr logfile backups (default 10)
+;stderr_capture_maxbytes=1MB   ; number of bytes in 'capturemode' (default 0)
+;stderr_events_enabled=false   ; emit events on stderr writes (default false)
+;environment=A=1,B=2           ; process environment additions (def no adds)
+;serverurl=AUTO                ; override serverurl computation (childutils)
+
+; The below sample eventlistener section shows all possible
+; eventlistener subsection values, create one or more 'real'
+; eventlistener: sections to be able to handle event notifications
+; sent by supervisor.
+
+;[eventlistener:theeventlistenername]
+;command=/bin/eventlistener    ; the program (relative uses PATH, can take args)
+;process_name=%(program_name)s ; process_name expr (default %(program_name)s)
+;numprocs=1                    ; number of processes copies to start (def 1)
+;events=EVENT                  ; event notif. types to subscribe to (req'd)
+;buffer_size=10                ; event buffer queue size (default 10)
+;directory=/tmp                ; directory to cwd to before exec (def no cwd)
+;umask=022                     ; umask for process (default None)
+;priority=-1                   ; the relative start priority (default -1)
+;autostart=true                ; start at supervisord start (default: true)
+;autorestart=unexpected        ; whether/when to restart (default: unexpected)
+;startsecs=1                   ; number of secs prog must stay running (def. 1)
+;startretries=3                ; max # of serial start failures (default 3)
+;exitcodes=0,2                 ; 'expected' exit codes for process (default 0,2)
+;stopsignal=QUIT               ; signal used to kill process (default TERM)
+;stopwaitsecs=10               ; max num secs to wait b4 SIGKILL (default 10)
+;killasgroup=false             ; SIGKILL the UNIX process group (def false)
+;user=chrism                   ; setuid to this UNIX account to run the program
+;redirect_stderr=true          ; redirect proc stderr to stdout (default false)
+;stdout_logfile=/a/path        ; stdout log path, NONE for none; default AUTO
+;stdout_logfile_maxbytes=1MB   ; max # logfile bytes b4 rotation (default 50MB)
+;stdout_logfile_backups=10     ; # of stdout logfile backups (default 10)
+;stdout_events_enabled=false   ; emit events on stdout writes (default false)
+;stderr_logfile=/a/path        ; stderr log path, NONE for none; default AUTO
+;stderr_logfile_maxbytes=1MB   ; max # logfile bytes b4 rotation (default 50MB)
+;stderr_logfile_backups        ; # of stderr logfile backups (default 10)
+;stderr_events_enabled=false   ; emit events on stderr writes (default false)
+;environment=A=1,B=2           ; process environment additions
+;serverurl=AUTO                ; override serverurl computation (childutils)
+
+; The below sample group section shows all possible group values,
+; create one or more 'real' group: sections to create "heterogeneous"
+; process groups.
+
+;[group:thegroupname]
+;programs=progname1,progname2  ; each refers to 'x' in [program:x] definitions
+;priority=999                  ; the relative start priority (default 999)
+
+; The [include] section can just contain the "files" setting.  This
+; setting can list multiple files (separated by whitespace or
+; newlines).  It can also contain wildcards.  The filenames are
+; interpreted as relative to this file.  Included files *cannot*
+; include files themselves.
+
+[include]
+files = /etc/supervisor.d/nginx.ini /etc/supervisor.d/php.ini

--- a/etc/supervisord.test.conf
+++ b/etc/supervisord.test.conf
@@ -1,0 +1,131 @@
+; Sample supervisor config file.
+
+[unix_http_server]
+file=/run/supervisord.sock   ; (the path to the socket file)
+;chmod=0700                  ; socked file mode (default 0700)
+;chown=nobody:nogroup        ; socket file uid:gid owner
+;username=user               ; (default is no username (open server))
+;password=123                ; (default is no password (open server))
+
+;[inet_http_server]          ; inet (TCP) server disabled by default
+;port=127.0.0.1:9001         ; (ip_address:port specifier, *:port for all iface)
+;username=user               ; (default is no username (open server))
+;password=123                ; (default is no password (open server))
+
+[supervisord]
+logfile=/var/log/supervisord.log ; (main log file;default $CWD/supervisord.log)
+;logfile_maxbytes=50MB       ; (max main logfile bytes b4 rotation;default 50MB)
+;logfile_backups=10          ; (num of main logfile rotation backups;default 10)
+loglevel=info                ; (log level;default info; others: debug,warn,trace)
+;pidfile=/run/supervisord.pid ; (supervisord pidfile;default supervisord.pid)
+;nodaemon=false              ; (start in foreground if true;default false)
+;minfds=1024                 ; (min. avail startup file descriptors;default 1024)
+;minprocs=200                ; (min. avail process descriptors;default 200)
+;umask=022                   ; (process file creation umask;default 022)
+;user=chrism                 ; (default is current user, required if root)
+;identifier=supervisor       ; (supervisord identifier, default is 'supervisor')
+;directory=/tmp              ; (default is not to cd during start)
+;nocleanup=true              ; (don't clean up tempfiles at start;default false)
+;childlogdir=/var/log/supervisor ; ('AUTO' child log dir, default $TEMP)
+;environment=KEY=value       ; (key value pairs to add to environment)
+;strip_ansi=false            ; (strip ansi escape codes in logs; def. false)
+
+; the below section must remain in the config file for RPC
+; (supervisorctl/web interface) to work, additional interfaces may be
+; added by defining them in separate rpcinterface: sections
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+serverurl=unix:///run/supervisord.sock ; use a unix:// URL  for a unix socket
+;serverurl=http://127.0.0.1:9001 ; use an http:// url to specify an inet socket
+;username=chris              ; should be same as http_username if set
+;password=123                ; should be same as http_password if set
+;prompt=mysupervisor         ; cmd line prompt (default "supervisor")
+;history_file=~/.sc_history  ; use readline history if available
+
+; The below sample program section shows all possible program subsection values,
+; create one or more 'real' program: sections to be able to control them under
+; supervisor.
+
+;[program:theprogramname]
+;command=/bin/cat              ; the program (relative uses PATH, can take args)
+;process_name=%(program_name)s ; process_name expr (default %(program_name)s)
+;numprocs=1                    ; number of processes copies to start (def 1)
+;directory=/tmp                ; directory to cwd to before exec (def no cwd)
+;umask=022                     ; umask for process (default None)
+;priority=999                  ; the relative start priority (default 999)
+;autostart=true                ; start at supervisord start (default: true)
+;autorestart=unexpected        ; whether/when to restart (default: unexpected)
+;startsecs=1                   ; number of secs prog must stay running (def. 1)
+;startretries=3                ; max # of serial start failures (default 3)
+;exitcodes=0,2                 ; 'expected' exit codes for process (default 0,2)
+;stopsignal=QUIT               ; signal used to kill process (default TERM)
+;stopwaitsecs=10               ; max num secs to wait b4 SIGKILL (default 10)
+;killasgroup=false             ; SIGKILL the UNIX process group (def false)
+;user=chrism                   ; setuid to this UNIX account to run the program
+;redirect_stderr=true          ; redirect proc stderr to stdout (default false)
+;stdout_logfile=/a/path        ; stdout log path, NONE for none; default AUTO
+;stdout_logfile_maxbytes=1MB   ; max # logfile bytes b4 rotation (default 50MB)
+;stdout_logfile_backups=10     ; # of stdout logfile backups (default 10)
+;stdout_capture_maxbytes=1MB   ; number of bytes in 'capturemode' (default 0)
+;stdout_events_enabled=false   ; emit events on stdout writes (default false)
+;stderr_logfile=/a/path        ; stderr log path, NONE for none; default AUTO
+;stderr_logfile_maxbytes=1MB   ; max # logfile bytes b4 rotation (default 50MB)
+;stderr_logfile_backups=10     ; # of stderr logfile backups (default 10)
+;stderr_capture_maxbytes=1MB   ; number of bytes in 'capturemode' (default 0)
+;stderr_events_enabled=false   ; emit events on stderr writes (default false)
+;environment=A=1,B=2           ; process environment additions (def no adds)
+;serverurl=AUTO                ; override serverurl computation (childutils)
+
+; The below sample eventlistener section shows all possible
+; eventlistener subsection values, create one or more 'real'
+; eventlistener: sections to be able to handle event notifications
+; sent by supervisor.
+
+;[eventlistener:theeventlistenername]
+;command=/bin/eventlistener    ; the program (relative uses PATH, can take args)
+;process_name=%(program_name)s ; process_name expr (default %(program_name)s)
+;numprocs=1                    ; number of processes copies to start (def 1)
+;events=EVENT                  ; event notif. types to subscribe to (req'd)
+;buffer_size=10                ; event buffer queue size (default 10)
+;directory=/tmp                ; directory to cwd to before exec (def no cwd)
+;umask=022                     ; umask for process (default None)
+;priority=-1                   ; the relative start priority (default -1)
+;autostart=true                ; start at supervisord start (default: true)
+;autorestart=unexpected        ; whether/when to restart (default: unexpected)
+;startsecs=1                   ; number of secs prog must stay running (def. 1)
+;startretries=3                ; max # of serial start failures (default 3)
+;exitcodes=0,2                 ; 'expected' exit codes for process (default 0,2)
+;stopsignal=QUIT               ; signal used to kill process (default TERM)
+;stopwaitsecs=10               ; max num secs to wait b4 SIGKILL (default 10)
+;killasgroup=false             ; SIGKILL the UNIX process group (def false)
+;user=chrism                   ; setuid to this UNIX account to run the program
+;redirect_stderr=true          ; redirect proc stderr to stdout (default false)
+;stdout_logfile=/a/path        ; stdout log path, NONE for none; default AUTO
+;stdout_logfile_maxbytes=1MB   ; max # logfile bytes b4 rotation (default 50MB)
+;stdout_logfile_backups=10     ; # of stdout logfile backups (default 10)
+;stdout_events_enabled=false   ; emit events on stdout writes (default false)
+;stderr_logfile=/a/path        ; stderr log path, NONE for none; default AUTO
+;stderr_logfile_maxbytes=1MB   ; max # logfile bytes b4 rotation (default 50MB)
+;stderr_logfile_backups        ; # of stderr logfile backups (default 10)
+;stderr_events_enabled=false   ; emit events on stderr writes (default false)
+;environment=A=1,B=2           ; process environment additions
+;serverurl=AUTO                ; override serverurl computation (childutils)
+
+; The below sample group section shows all possible group values,
+; create one or more 'real' group: sections to create "heterogeneous"
+; process groups.
+
+;[group:thegroupname]
+;programs=progname1,progname2  ; each refers to 'x' in [program:x] definitions
+;priority=999                  ; the relative start priority (default 999)
+
+; The [include] section can just contain the "files" setting.  This
+; setting can list multiple files (separated by whitespace or
+; newlines).  It can also contain wildcards.  The filenames are
+; interpreted as relative to this file.  Included files *cannot*
+; include files themselves.
+
+[include]
+files = /etc/supervisor.d/*.ini

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,12 @@
 #!/bin/sh
+
+# Set Supervisor default config (run tests or not)
+if [ "$PHPMYADMIN_RUN_TEST" = true ] ; then
+    CONFIG_PATH="/etc/supervisord.test.conf"
+else
+    CONFIG_PATH="/etc/supervisord.conf"
+fi
+
 if [ ! -f /etc/phpmyadmin/config.secret.inc.php ] ; then
     cat > /etc/phpmyadmin/config.secret.inc.php <<EOT
 <?php
@@ -18,5 +26,5 @@ touch /var/log/php-fpm.log
 chown nobody:nobody /var/log/php-fpm.log
 
 if [ "$1" = 'phpmyadmin' ]; then
-    exec supervisord --nodaemon --configuration="/etc/supervisord.conf" --loglevel=info
+    exec supervisord --nodaemon --configuration=$CONFIG_PATH --loglevel=info
 fi

--- a/test-docker.sh
+++ b/test-docker.sh
@@ -1,26 +1,81 @@
 #!/bin/sh
 
-set -x
+set -e
 
 NAME="$1"
-PORT="$2"
+
+if [ -n "$2" ] ; then
+    PORT="$2"
+    TESTSUITE_PORT=$2
+fi
+
 if [ -n "$3" ] ; then
     SERVER="--server $3"
+    PMA_HOST=$3
 else
     SERVER=''
 fi
 
-URL=http://127.0.0.1:$PORT/
+# Set PHPMyAdmin environment
+PHPMYADMIN_HOSTNAME=${TESTSUITE_HOSTNAME:=localhost}
+PHPMYADMIN_PORT=${TESTSUITE_PORT:=80}
+PHPMYADMIN_URL=http://$PHPMYADMIN_HOSTNAME:$PORT/
 
-# Wait for container to start
+# Color text output
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
 ret=0
+# Check if script is running inside container
+if [ -f /.dockerenv ] ; then
+    echo "Tests running inside container..."
+
+    # Set database environment
+    PHPMYADMIN_DB_HOSTNAME=${PMA_HOST:=localhost}
+    PHPMYADMIN_DB_PORT=${PMA_PORT:=3306}
+    PHPMYADMIN_DB_URL=http://$PHPMYADMIN_DB_HOSTNAME:$PHPMYADMIN_DB_PORT/
+
+    # Wait for database to start
+    TIMEOUT=0
+    while ! curl "$PHPMYADMIN_DB_URL" &>/dev/null; do
+        echo "Waiting for ${PHPMYADMIN_DB_HOSTNAME} database start..."
+        sleep 10
+        TIMEOUT=$((TIMEOUT + 1))
+        if [ $TIMEOUT -gt 3 ] ; then
+            echo "Failed to connect ${PHPMYADMIN_DB_HOSTNAME} database!"
+            echo -e "Result of ${PHPMYADMIN_DB_HOSTNAME} tests: ${RED}FAILED${NC}"
+            ret=1
+            exit 1
+        fi
+    done
+
+    # Install mechanize via pip package manager
+    if ! python -c "import mechanize" &> /dev/null ; then
+        pip install --user mechanize
+        ret=$?
+    fi
+
+    # Install html5lib via pip package manager
+    if ! python -c "import html5lib" &> /dev/null ; then
+        pip install --user html5lib
+        ret=$?
+    fi
+else
+    echo "Tests running outside container..."
+    docker ps -a
+    COMMAND_HOST="docker exec ${NAME}"
+fi
+
+# Wait for container to start
 TIMEOUT=0
-while ! docker exec "$NAME" ps aux | grep -q nginx ; do
-    echo 'Waiting for start...'
+while ! $COMMAND_HOST ps aux | grep -q nginx ; do
+    echo "Waiting for PHPMyAdmin start..."
     sleep 1
     TIMEOUT=$((TIMEOUT + 1))
     if [ $TIMEOUT -gt 10 ] ; then
-        echo "Failed to wait!"
+        echo "Failed to connect PHPMyAdmin!"
+        echo -e "Result of ${PHPMYADMIN_DB_HOSTNAME} tests: ${RED}FAILED${NC}"
         ret=1
         exit 1
     fi
@@ -28,20 +83,19 @@ done
 
 # Perform tests
 if [ $ret -eq 0 ] ; then
-    python phpmyadmin_test.py --url "$URL" --username root --password $TESTSUITE_PASSWORD $SERVER
+    python phpmyadmin_test.py --url "$PHPMYADMIN_URL" --username root --password $TESTSUITE_PASSWORD $SERVER
     ret=$?
 fi
 
 # Show debug output in case of failure
 if [ $ret -ne 0 ] ; then
-    curl "$URL"
-    docker ps -a
-    docker exec "$NAME" ps faux
-    docker exec "$NAME" cat /var/log/php-fpm.log
-    docker exec "$NAME" cat /var/log/nginx-error.log
-    docker exec "$NAME" cat /var/log/supervisord.log
+    curl "$PHPMYADMIN_URL"
+    $COMMAND_HOST ps faux
+    $COMMAND_HOST cat /var/log/php-fpm.log
+    $COMMAND_HOST cat /var/log/nginx-error.log
+    $COMMAND_HOST cat /var/log/supervisord.log
+    echo -e "Result of ${PHPMYADMIN_DB_HOSTNAME} tests: ${RED}FAILED${NC}"
     exit $ret
 fi
 
-# List processes
-docker exec "$NAME" ps faux
+echo -e "Result of ${PHPMYADMIN_DB_HOSTNAME} tests: ${GREEN}SUCCESS${NC}"


### PR DESCRIPTION
Simulate the CI's tests with the docker-compose environment running in local. Adding the changes:
      - Add pip and curl Alpine packages on Dockerfile
      - Add env variable to run or not the tests
      - Create MariaDB and MySQL supervisor process
      - Create supervisor test config file
      - Run tests inside or not container
      - Run tests automatically on docker provision