### PR TITLE
Remove link to db container

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ docker run --name myadmin -d -e PMA_HOST=dbhost -p 8080:80 phpmyadmin/phpmyadmin
 You can use arbitrary servers by adding ENV variable `PMA_ARBITRARY=1` to the startup command:
 
 ```
-docker run --name myadmin -d --link mysql_db_server:db -p 8080:80 -e PMA_ARBITRARY=1 phpmyadmin/phpmyadmin
+docker run --name myadmin -d -e PMA_ARBITRARY=1 -p 8080:80 phpmyadmin/phpmyadmin
 ```
 
 ## Usage with docker-compose and arbitrary server


### PR DESCRIPTION
You don't need linking to db container in case of arbitrary server