### PR TITLE
Use upstream PHP FPM Alpine Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.1-fpm-alpine
+FROM php:7.2-fpm-alpine
 
 # Install dependencies
 RUN apk add --no-cache --virtual .build-deps \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,27 @@
-FROM alpine:3.7
+FROM php:7.1-fpm-alpine
 
 # Install dependencies
-RUN apk add --no-cache php7-session php7-mysqli php7-mbstring php7-xml php7-gd php7-zlib php7-bz2 php7-zip php7-openssl php7-curl php7-opcache php7-json nginx php7-fpm supervisor
+RUN apk add --no-cache --virtual .build-deps \
+		bzip2-dev \
+		freetype-dev \
+		libjpeg-turbo-dev \
+		libpng-dev \
+		libwebp-dev \
+		libxpm-dev \
+	; \
+	\
+	docker-php-ext-configure gd --with-freetype-dir=/usr --with-jpeg-dir=/usr --with-webp-dir=/usr --with-png-dir=/usr --with-xpm-dir=/usr; \
+	docker-php-ext-install bz2 gd mysqli opcache zip; \
+	\
+	runDeps="$( \
+		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local/lib/php/extensions \
+			| tr ',' '\n' \
+			| sort -u \
+			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+	)"; \
+	apk add --virtual .phpmyadmin-phpexts-rundeps $runDeps; \
+	apk del .build-deps; \
+	apk add --no-cache nginx supervisor
 
 # Include keyring to verify download
 COPY phpmyadmin.keyring /
@@ -20,22 +40,22 @@ LABEL version=$VERSION
 
 # Download tarball, verify it using gpg and extract
 RUN set -x \
-    && GNUPGHOME="$(mktemp -d)" \
-    && export GNUPGHOME \
-    && apk add --no-cache curl gnupg \
-    && curl --output phpMyAdmin.tar.gz --location $URL \
-    && curl --output phpMyAdmin.tar.gz.asc --location $URL.asc \
-    && gpgv --keyring /phpmyadmin.keyring phpMyAdmin.tar.gz.asc phpMyAdmin.tar.gz \
-    && apk del --no-cache curl gnupg \
-    && rm -rf "$GNUPGHOME" \
-    && tar xzf phpMyAdmin.tar.gz \
-    && rm -f phpMyAdmin.tar.gz phpMyAdmin.tar.gz.asc \
-    && mv phpMyAdmin-$VERSION-all-languages /www \
-    && rm -rf /www/setup/ /www/examples/ /www/test/ /www/po/ /www/composer.json /www/RELEASE-DATE-$VERSION \
-    && sed -i "s@define('CONFIG_DIR'.*@define('CONFIG_DIR', '/etc/phpmyadmin/');@" /www/libraries/vendor_config.php \
-    && chown -R root:nobody /www \
-    && find /www -type d -exec chmod 750 {} \; \
-    && find /www -type f -exec chmod 640 {} \;
+	&& GNUPGHOME="$(mktemp -d)" \
+	&& export GNUPGHOME \
+	&& apk add --no-cache curl gnupg \
+	&& curl --output phpMyAdmin.tar.gz --location $URL \
+	&& curl --output phpMyAdmin.tar.gz.asc --location $URL.asc \
+	&& gpgv --keyring /phpmyadmin.keyring phpMyAdmin.tar.gz.asc phpMyAdmin.tar.gz \
+	&& apk del --no-cache curl gnupg \
+	&& rm -rf "$GNUPGHOME" \
+	&& tar xzf phpMyAdmin.tar.gz \
+	&& rm -f phpMyAdmin.tar.gz phpMyAdmin.tar.gz.asc \
+	&& mv phpMyAdmin-$VERSION-all-languages /www \
+	&& rm -rf /www/setup/ /www/examples/ /www/test/ /www/po/ /www/composer.json /www/RELEASE-DATE-$VERSION \
+	&& sed -i "s@define('CONFIG_DIR'.*@define('CONFIG_DIR', '/etc/phpmyadmin/');@" /www/libraries/vendor_config.php \
+	&& chown -R root:nobody /www \
+	&& find /www -type d -exec chmod 750 {} \; \
+	&& find /www -type f -exec chmod 640 {} \;
 
 # Add directory for sessions to allow session persistence
 RUN mkdir /sessions

--- a/etc/supervisor.d/php.ini
+++ b/etc/supervisor.d/php.ini
@@ -1,5 +1,5 @@
 [program:php-fpm]
-command=php-fpm7 --nodaemonize --fpm-config /etc/php-fpm.conf -c /etc/php.ini
+command=php-fpm --nodaemonize --fpm-config /etc/php-fpm.conf -c /etc/php.ini
 user=nobody
 autostart=true
 autorestart=true

--- a/testing/phpmyadmin_test.py
+++ b/testing/phpmyadmin_test.py
@@ -15,8 +15,8 @@ def test_content(match, content):
 
 def test_phpmyadmin(url, username, password, server=None, sqlfile=None):
     if sqlfile is None:
-        if os.path.exists('./world.sql'):
-            sqlfile = './world.sql'
+        if os.path.exists('/world.sql'):
+            sqlfile = '/world.sql'
         else:
             sqlfile = './testing/world.sql'
     br = mechanize.Browser()

--- a/testing/test-docker.sh
+++ b/testing/test-docker.sh
@@ -69,8 +69,8 @@ done
 
 # Perform tests
 if [ $ret -eq 0 ] ; then
-    if [ -f ./phpmyadmin_test.py ] ; then
-        FILENAME=./phpmyadmin_test.py
+    if [ -f /phpmyadmin_test.py ] ; then
+        FILENAME=/phpmyadmin_test.py
     else
         FILENAME=./testing/phpmyadmin_test.py
     fi

--- a/testing/test-docker.sh
+++ b/testing/test-docker.sh
@@ -71,6 +71,8 @@ done
 if [ $ret -eq 0 ] ; then
     if [ -f /phpmyadmin_test.py ] ; then
         FILENAME=/phpmyadmin_test.py
+    elif [ -f ./phpmyadmin_test.py ] ; then
+        FILENAME=./phpmyadmin_test.py
     else
         FILENAME=./testing/phpmyadmin_test.py
     fi


### PR DESCRIPTION
This switches the base to the upstream PHP FPM Alpine Docker image, so we can benefit from the maintenance there.
I included and configured the same php extensions as before.

This might be a dependency task of #56.