### PR TITLE
Avoid "TempDir is not accessible" message

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,9 @@ RUN set -x \
     && find /www -type f -exec chmod 640 {} \;
 
 # Add directory for sessions to allow session persistence
-RUN mkdir /sessions
+RUN mkdir /sessions \
+    && mkdir -p /www/tmp \
+    && chmod -R 777 /www/tmp
 
 # We expose phpMyAdmin on port 80
 EXPOSE 80


### PR DESCRIPTION
phpmyadmin should create the tmp dir for twig templates.

This is the original issue: https://github.com/phpmyadmin/phpmyadmin/issues/14172