### PR TITLE
Use "nogroup" as group name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ RUN set -ex; \
     mv phpMyAdmin-$VERSION-all-languages /www; \
     rm -rf /www/setup/ /www/examples/ /www/test/ /www/po/ /www/composer.json /www/RELEASE-DATE-$VERSION; \
     sed -i "s@define('CONFIG_DIR'.*@define('CONFIG_DIR', '/etc/phpmyadmin/');@" /www/libraries/vendor_config.php; \
-    chown -R root:nobody /www; \
+    chown -R nobody:nogroup /www; \
     find /www -type d -exec chmod 750 {} \; ; \
     find /www -type f -exec chmod 640 {} \; ; \
     apk del .fetch-deps

--- a/etc/nginx.conf
+++ b/etc/nginx.conf
@@ -1,4 +1,4 @@
-user nobody;
+user nobody nogroup;
 worker_processes 4;
 
 daemon off;

--- a/etc/php-fpm.conf
+++ b/etc/php-fpm.conf
@@ -4,7 +4,7 @@ log_level = warning
 
 [www]
 user = nobody
-group = nobody
+group = nogroup
 listen = /var/run/php/php-fpm.sock
 listen.mode = 0660
 chdir = /www

--- a/run.sh
+++ b/run.sh
@@ -11,11 +11,11 @@ if [ ! -f /etc/phpmyadmin/config.user.inc.php ]; then
 fi
 
 mkdir -p /var/nginx/client_body_temp
-chown nobody:nobody /sessions /var/nginx/client_body_temp
+chown nobody:nogroup /sessions /var/nginx/client_body_temp
 mkdir -p /var/run/php/
-chown nobody:nobody /var/run/php/
+chown nobody:nogroup /var/run/php/
 touch /var/log/php-fpm.log
-chown nobody:nobody /var/log/php-fpm.log
+chown nobody:nogroup /var/log/php-fpm.log
 
 if [ "$1" = 'phpmyadmin' ]; then
     exec supervisord --nodaemon --configuration="/etc/supervisord.conf" --loglevel=info


### PR DESCRIPTION
`nobody` seems not to be a valid group, so using `nogroup` instead.
This should be carefully tested, I didn't run into any issue myself.