### PR TITLE
Run supervisord in CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,4 +77,4 @@ RUN mkdir /sessions \
 EXPOSE 80
 
 ENTRYPOINT [ "/run.sh" ]
-CMD ["phpmyadmin"]
+CMD ["supervisord", "-n"]

--- a/run.sh
+++ b/run.sh
@@ -17,6 +17,4 @@ chown nobody:nobody /var/run/php/
 touch /var/log/php-fpm.log
 chown nobody:nobody /var/log/php-fpm.log
 
-if [ "$1" = 'phpmyadmin' ]; then
-    exec supervisord --nodaemon --configuration="/etc/supervisord.conf" --loglevel=info
-fi
+exec "$@"


### PR DESCRIPTION
Because of the condition it's impossible to run anything else than `phpmyadmin`. The `exec "$@"` in `run.sh` fixes this.
`loglevel=info` is already the [default](http://supervisord.org/logging.html#activity-log).