### PR TITLE
Trims whitespaces in PMA_HOSTS, PMA_PORTS and PMA_VERBOSES

### DIFF
--- a/etc/phpmyadmin/config.inc.php
+++ b/etc/phpmyadmin/config.inc.php
@@ -52,9 +52,9 @@ if (!empty($_ENV['PMA_HOST'])) {
     $verbose = array($_ENV['PMA_VERBOSE']);
     $ports = array($_ENV['PMA_PORT']);
 } elseif (!empty($_ENV['PMA_HOSTS'])) {
-    $hosts = explode(',', $_ENV['PMA_HOSTS']);
-    $verbose = explode(',', $_ENV['PMA_VERBOSES']);
-    $ports = explode(',', $_ENV['PMA_PORTS']);
+    $hosts = array_map('trim', explode(',', $_ENV['PMA_HOSTS']));
+    $verbose = array_map('trim', explode(',', $_ENV['PMA_VERBOSES']));
+    $ports = array_map('trim', explode(',', $_ENV['PMA_PORTS']));
 }
 
 /* Server settings */


### PR DESCRIPTION
I encountered a problem when configuring hosts via yaml multiline:

```yaml
environment:
    PMA_HOSTS: >
        host_a,
        host_b,
        host_c
```
This config resolves to `PMA_HOSTS=host_a, host_b, host_c` which leads to not being able to login to `host_b` and `host_c` because of leading whitespaces.

It would be really useful to be able to list hosts in multiple lines for readability and also version control diffing.

Therefore this patch simply trims each value in `PMA_HOSTS`, `PMA_PORTS` and `PMA_VERBOSES`.