### PR TITLE
Update run.sh

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -17,4 +17,6 @@ chown nobody:nogroup /var/run/php/
 touch /var/log/php-fpm.log
 chown nobody:nogroup /var/log/php-fpm.log
 
+chmod 644 /etc/phpmyadmin/*
+
 exec "$@"


### PR DESCRIPTION
when I start the phpMyAdmin Container, I got the below error
phpMyAdmin - Error
Failed to load phpMyAdmin configuration (./../etc/phpmyadmin/config.inc.php:3): require(): Failed opening required '/etc/phpmyadmin/config.secret.inc.php' (include_path='.:/usr/local/lib/php')

I found the access right of the config.secret.inc.php is not correct, I added the below cmd in run.sh, then build the image, It can work

chmod 644 /etc/phpmyadmin/*