### PR TITLE
Hide PHP version

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Set the variable ``PMA_ABSOLUTE_URI`` to the fully-qualified path (``https://pma
 * ``PMA_PORTS`` -  define comma separated list of ports of the MySQL servers
 * ``PMA_USER`` and ``PMA_PASSWORD`` - define username to use for config authentication method
 * ``PMA_ABSOLUTE_URI`` - define user-facing URI
+* ``HIDE_PHP_VERSION`` - if defined, will hide the php version (`expose_php = Off`). Set to any value (such as HIDE_PHP_VERSION=true).
 
 For usage with Docker secrets, appending ``_FILE`` to any environment variable is allowed:
 ```

--- a/apache/docker-entrypoint.sh
+++ b/apache/docker-entrypoint.sh
@@ -47,4 +47,9 @@ EOT
     fi
 fi
 
+if [ ! -z "${HIDE_PHP_VERSION}" ]; then
+    echo "PHP version is now hidden."
+    echo 'expose_php = Off' > $PHP_INI_DIR/conf.d/phpmyadmin-hide-php-version.ini
+fi
+
 exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -47,4 +47,9 @@ EOT
     fi
 fi
 
+if [ ! -z "${HIDE_PHP_VERSION}" ]; then
+    echo "PHP version is now hidden."
+    echo -e 'expose_php = Off\n' > $PHP_INI_DIR/conf.d/phpmyadmin-hide-php-version.ini
+fi
+
 exec "$@"

--- a/fpm-alpine/docker-entrypoint.sh
+++ b/fpm-alpine/docker-entrypoint.sh
@@ -47,4 +47,9 @@ EOT
     fi
 fi
 
+if [ ! -z "${HIDE_PHP_VERSION}" ]; then
+    echo "PHP version is now hidden."
+    echo 'expose_php = Off' > $PHP_INI_DIR/conf.d/phpmyadmin-hide-php-version.ini
+fi
+
 exec "$@"

--- a/fpm/docker-entrypoint.sh
+++ b/fpm/docker-entrypoint.sh
@@ -47,4 +47,9 @@ EOT
     fi
 fi
 
+if [ ! -z "${HIDE_PHP_VERSION}" ]; then
+    echo "PHP version is now hidden."
+    echo 'expose_php = Off' > $PHP_INI_DIR/conf.d/phpmyadmin-hide-php-version.ini
+fi
+
 exec "$@"


### PR DESCRIPTION
Simple PR to hide the PHP version by adding `expose_php = Off` to `php.ini` for security reasons. When working behind a reverse proxy it is possible to ignore the header, but disabling it for everyone might be still the better choice. Change tested and working.