### PR TITLE
Make PMA's ExecTimeLimit configurable via Environment Vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Set the variable ``PMA_ABSOLUTE_URI`` to the fully-qualified path (``https://pma
 * ``PMA_PORTS`` -  define comma separated list of ports of the MySQL servers
 * ``PMA_USER`` and ``PMA_PASSWORD`` - define username to use for config authentication method
 * ``PMA_ABSOLUTE_URI`` - define user-facing URI
+* ``PMA_EXEC_TIME_LIMIT`` - define execution time limit for PMA (default: 300)
 
 For more detailed documentation see https://docs.phpmyadmin.net/en/latest/setup.html#installing-using-docker
 

--- a/etc/phpmyadmin/config.inc.php
+++ b/etc/phpmyadmin/config.inc.php
@@ -43,6 +43,11 @@ if (isset($_ENV['PMA_ABSOLUTE_URI'])) {
     $cfg['PmaAbsoluteUri'] = trim($_ENV['PMA_ABSOLUTE_URI']);
 }
 
+/* Configure ExecTimeLimit from ENV */
+if (isset($_ENV['PMA_EXEC_TIME_LIMIT'])) {
+    $cfg['ExecTimeLimit'] = trim($_ENV['PMA_EXEC_TIME_LIMIT']);
+}
+
 /* Figure out hosts */
 
 /* Fallback to default linked */


### PR DESCRIPTION
PHPMyAdmin's default ExecTimeLimit is 300 by default (5 mins) which is a bit short. If we are trying to import a large DB, it will time out with the following message:

'Script timeout passed, if you want to finish import, please resubmit the same file and import will resume.'

This commit makes it configurable via ENV