### PR TITLE
Add generate-stackbrew-library.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,21 @@ You can use following tags on Docker hub:
 
 * `latest` - latest stable release
 * `4.8` - latest stable release for the 4.8 version
-* `edge` - bleeding edge docker image (contains stable phpMyAdmin, but the Docker image changes might not yet be fully tested)
-* `edge-4.8` - bleeding edge docker image + latest snapshots from 4.8 branch (currently master)
+* `4.8.5` - specific patch release for the 4.8 version
+
+For each tag the following variants are provided:
+
+### apache
+
+This starts an Apache webserver with PHP, so you can use phpMyAdmin out of the box.
+
+### fpm-alpine
+
+This image has a very small footprint. It is based on Alpine Linux and starts only a PHP FPM process. Use this variant if you already have a seperate webserver. If you need more tools, that are not available on Alpine Linux, use the fpm image instead.
+
+### fpm
+
+This image starts only a PHP FPM container. Use this variant if you already have a seperate webserver.
 
 ## Usage with linked server
 

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+set -e
+
+self="$(basename "$BASH_SOURCE")"
+cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
+
+# Get the most recent commit which modified any of "$@".
+fileCommit() {
+	git log -1 --format='format:%H' HEAD -- "$@"
+}
+
+# Get the most recent commit which modified "$1/Dockerfile" or any file that
+# the Dockerfile copies into the rootfs (with COPY).
+dockerfileCommit() {
+	local dir="$1"; shift
+	(
+		cd "$dir";
+		fileCommit Dockerfile \
+			$(git show HEAD:./Dockerfile | awk '
+				toupper($1) == "COPY" {
+					for (i = 2; i < NF; i++)
+							print $i;
+				}
+			')
+	)
+}
+
+# depends on docker library
+#getArches() {
+#	local repo="$1"; shift
+#	local officialImagesUrl='https://github.com/docker-library/official-images/raw/master/library/'
+#
+#	eval "declare -g -A parentRepoToArches=( $(
+#		find -name 'Dockerfile' -exec awk '
+#				toupper($1) == "FROM" && $2 !~ /^('"$repo"'|scratch|microsoft\/[^:]+)(:|$)/ {
+#					print "'"$officialImagesUrl"'" $2
+#				}
+#			' '{}' + \
+#			| sort -u \
+#			| xargs bashbrew cat --format '[{{ .RepoName }}:{{ .TagName }}]="{{ join " " .TagEntry.Architectures }}"'
+#	) )"
+#}
+#getArches 'phpmyadmin'
+
+# Header.
+cat <<-EOH
+# This file is generated via https://github.com/phpmyadmin/docker/blob/$(fileCommit "$self")/$self
+Maintainers: Isaac Bennetch <bennetch@gmail.com>
+             Michal Čiha <michal@cihar.com>
+GitRepo: https://github.com/phpmyadmin/docker.git
+EOH
+
+# prints "$2$1$3$1...$N"
+join() {
+	local sep="$1"; shift
+	local out; printf -v out "${sep//%/%%}%s" "$@"
+	echo "${out#$sep}"
+}
+
+latest="$(
+	git ls-remote --tags https://github.com/phpmyadmin/phpmyadmin.git \
+		| cut -d/ -f3 \
+		| grep -vE -- '-rc|-b' \
+		| sort -V \
+		| tail -1
+)"
+
+for variant in apache fpm fpm-alpine; do
+	commit="$(dockerfileCommit "$variant")"
+	fullversion="$(git show "$commit":"$variant/Dockerfile" | awk '$1 == "ENV" && $2 == "VERSION" { print $3; exit }')"
+
+	versionAliases=( "$fullversion" "${fullversion%.*}" "${fullversion%.*.*}" )
+	if [ "$fullversion" = "$latest" ]; then
+		versionAliases+=( "latest" )
+	fi
+
+	variantAliases=( "${versionAliases[@]/%/-$variant}" )
+	variantAliases=( "${variantAliases[@]//latest-}" )
+
+	if [ "$variant" = "apache" ]; then
+		variantAliases+=( "${versionAliases[@]}" )
+	fi
+
+	variantParent="$(awk 'toupper($1) == "FROM" { print $2 }' "$variant/Dockerfile")"
+
+	# depends on docker library
+	#variantArches="${parentRepoToArches[$variantParent]}"
+	variantArches="amd64 arm32v7 arm64v8 i386 ppc64le"
+
+	cat <<-EOE
+
+		Tags: $(join ', ' "${variantAliases[@]}")
+		Architectures: $(join ', ' $variantArches)
+		GitCommit: $commit
+		Directory: $variant
+	EOE
+done

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -46,7 +46,7 @@ dockerfileCommit() {
 cat <<-EOH
 # This file is generated via https://github.com/phpmyadmin/docker/blob/$(fileCommit "$self")/$self
 Maintainers: Isaac Bennetch <bennetch@gmail.com>
-             Michal Čiha <michal@cihar.com>
+             Michal Čihar <michal@cihar.com>
 GitRepo: https://github.com/phpmyadmin/docker.git
 EOH
 

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -46,7 +46,7 @@ dockerfileCommit() {
 cat <<-EOH
 # This file is generated via https://github.com/phpmyadmin/docker/blob/$(fileCommit "$self")/$self
 Maintainers: Isaac Bennetch <bennetch@gmail.com>
-             Michal Čihar <michal@cihar.com>
+             Michal Čihař <michal@cihar.com>
 GitRepo: https://github.com/phpmyadmin/docker.git
 EOH
 


### PR DESCRIPTION
This script outputs the format used by the [docker library](https://github.com/docker-library/official-images/tree/master/library).

<details>
<summary>Example output</summary>

```
# This file is generated via https://github.com/phpmyadmin/docker/blob//generate-stackbrew-library.sh
Maintainers: Isaac Bennetch <bennetch@gmail.com>
             Michal Čiha <michal@cihar.com>
GitRepo: https://github.com/phpmyadmin/docker.git

Tags: 4.8.5-apache, 4.8-apache, 4-apache, 4.8.5, 4.8, 4
Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
GitCommit: 78e3cb7aba41b233281f81d8b264d95505c43c96
Directory: apache

Tags: 4.8.5-fpm, 4.8-fpm, 4-fpm
Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
GitCommit: 78e3cb7aba41b233281f81d8b264d95505c43c96
Directory: fpm

Tags: 4.8.5-fpm-alpine, 4.8-fpm-alpine, 4-fpm-alpine
Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
GitCommit: 78e3cb7aba41b233281f81d8b264d95505c43c96
Directory: fpm-alpine
```
</details>