### PR TITLE
Fix makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 DOCKER_REPO = phpmyadmin/phpmyadmin
 
-.PHONY: all build build_nc run logs clean stop rm prune
+.PHONY: all build build-apache build-fpm build-fpm-alpine run logs clean stop rm prune
 
 all: build run logs
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 DOCKER_REPO = phpmyadmin/phpmyadmin
 
-.PHONY: all build build-apache build-fpm build-fpm-alpine run logs clean stop rm prune
+.PHONY: all build run logs clean stop rm prune
 
 all: build run logs
 


### PR DESCRIPTION
As we have removed the `build_nc` function from the makefile in PR #200 but we didn't remove this function from the `.PHONY` statement. I have updated it with our latest changes.