### PR TITLE
Drop opcache from cli actions

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -36,7 +36,6 @@ RUN { \
         echo 'opcache.max_accelerated_files=4000'; \
         echo 'opcache.revalidate_freq=2'; \
         echo 'opcache.fast_shutdown=1'; \
-        echo 'opcache.enable_cli=1'; \
     } > /usr/local/etc/php/conf.d/opcache-recommended.ini; \
     \
     { \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -39,7 +39,6 @@ RUN { \
         echo 'opcache.max_accelerated_files=4000'; \
         echo 'opcache.revalidate_freq=2'; \
         echo 'opcache.fast_shutdown=1'; \
-        echo 'opcache.enable_cli=1'; \
     } > /usr/local/etc/php/conf.d/opcache-recommended.ini; \
     \
     { \

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -39,7 +39,6 @@ RUN { \
         echo 'opcache.max_accelerated_files=4000'; \
         echo 'opcache.revalidate_freq=2'; \
         echo 'opcache.fast_shutdown=1'; \
-        echo 'opcache.enable_cli=1'; \
     } > /usr/local/etc/php/conf.d/opcache-recommended.ini; \
     \
     { \

--- a/fpm-alpine/Dockerfile
+++ b/fpm-alpine/Dockerfile
@@ -36,7 +36,6 @@ RUN { \
         echo 'opcache.max_accelerated_files=4000'; \
         echo 'opcache.revalidate_freq=2'; \
         echo 'opcache.fast_shutdown=1'; \
-        echo 'opcache.enable_cli=1'; \
     } > /usr/local/etc/php/conf.d/opcache-recommended.ini; \
     \
     { \

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -39,7 +39,6 @@ RUN { \
         echo 'opcache.max_accelerated_files=4000'; \
         echo 'opcache.revalidate_freq=2'; \
         echo 'opcache.fast_shutdown=1'; \
-        echo 'opcache.enable_cli=1'; \
     } > /usr/local/etc/php/conf.d/opcache-recommended.ini; \
     \
     { \


### PR DESCRIPTION
https://github.com/docker-library/wordpress/issues/407

Before a68a25c673c8a0ca55589e81dd4540c2c31e9e97 this was in a inconsistent state.