### PR TITLE
Added healthecks

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -88,5 +88,8 @@ COPY config.inc.php /etc/phpmyadmin/config.inc.php
 # Copy main script
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 
+HEALTHCHECK --interval=5m --timeout=1s --start-period=5m \
+    CMD curl -f http://localhost/LICENSE || exit 1
+
 ENTRYPOINT [ "/docker-entrypoint.sh" ]
 CMD ["%%CMD%%"]

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -96,5 +96,8 @@ COPY config.inc.php /etc/phpmyadmin/config.inc.php
 # Copy main script
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 
+HEALTHCHECK --interval=5m --timeout=1s --start-period=5m \
+    CMD curl -f http://localhost/LICENSE || exit 1
+
 ENTRYPOINT [ "/docker-entrypoint.sh" ]
 CMD ["%%CMD%%"]


### PR DESCRIPTION
This seems a minor issue, but both images should now have the ability to check their own health. (by fetching the LICENSE. This could also be extended to a real PHP request to make sure all the requirements are still there (i.e. correctly configured PHP, MySQL et al)

But this at least should fix #182 

This does increase the docker required version to 1.12 (but that is `quite old` so shouldnt be a problem)