### PR TITLE
Implement #192 - override config using base64 encoded config in ENVs

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ Set the variable ``PMA_ABSOLUTE_URI`` to the fully-qualified path (``https://pma
 * ``PMA_USER`` and ``PMA_PASSWORD`` - define username to use for config authentication method
 * ``PMA_ABSOLUTE_URI`` - define user-facing URI
 * ``HIDE_PHP_VERSION`` - if defined, will hide the php version (`expose_php = Off`). Set to any value (such as HIDE_PHP_VERSION=true).
+* ``PMA_CONFIG_BASE64`` - if set, will override the default config.inc.php with the base64 decoded contents of the variable
+* ``PMA_USER_CONFIG_BASE64`` - if set, will override the default config.user.inc.php with the base64 decoded contents of the variable
 
 For usage with Docker secrets, appending ``_FILE`` to any environment variable is allowed:
 ```

--- a/apache/docker-entrypoint.sh
+++ b/apache/docker-entrypoint.sh
@@ -52,4 +52,14 @@ if [ ! -z "${HIDE_PHP_VERSION}" ]; then
     echo 'expose_php = Off' > $PHP_INI_DIR/conf.d/phpmyadmin-hide-php-version.ini
 fi
 
+if [ ! -z "${PMA_CONFIG_BASE64}" ]; then
+    echo "Adding the custom config.inc.php from base64."
+    echo "${PMA_CONFIG_BASE64}" | base64 -d > /etc/phpmyadmin/config.inc.php
+fi
+
+if [ ! -z "${PMA_USER_CONFIG_BASE64}" ]; then
+    echo "Adding the custom config.user.inc.php from base64."
+    echo "${PMA_USER_CONFIG_BASE64}" | base64 -d > /etc/phpmyadmin/config.user.inc.php
+fi
+
 exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -52,4 +52,14 @@ if [ ! -z "${HIDE_PHP_VERSION}" ]; then
     echo -e 'expose_php = Off\n' > $PHP_INI_DIR/conf.d/phpmyadmin-hide-php-version.ini
 fi
 
+if [ ! -z "${PMA_CONFIG_BASE64}" ]; then
+    echo "Adding the custom config.inc.php from base64."
+    echo "${PMA_CONFIG_BASE64}" | base64 -d > /etc/phpmyadmin/config.inc.php
+fi
+
+if [ ! -z "${PMA_USER_CONFIG_BASE64}" ]; then
+    echo "Adding the custom config.user.inc.php from base64."
+    echo "${PMA_USER_CONFIG_BASE64}" | base64 -d > /etc/phpmyadmin/config.user.inc.php
+fi
+
 exec "$@"

--- a/fpm-alpine/docker-entrypoint.sh
+++ b/fpm-alpine/docker-entrypoint.sh
@@ -52,4 +52,14 @@ if [ ! -z "${HIDE_PHP_VERSION}" ]; then
     echo 'expose_php = Off' > $PHP_INI_DIR/conf.d/phpmyadmin-hide-php-version.ini
 fi
 
+if [ ! -z "${PMA_CONFIG_BASE64}" ]; then
+    echo "Adding the custom config.inc.php from base64."
+    echo "${PMA_CONFIG_BASE64}" | base64 -d > /etc/phpmyadmin/config.inc.php
+fi
+
+if [ ! -z "${PMA_USER_CONFIG_BASE64}" ]; then
+    echo "Adding the custom config.user.inc.php from base64."
+    echo "${PMA_USER_CONFIG_BASE64}" | base64 -d > /etc/phpmyadmin/config.user.inc.php
+fi
+
 exec "$@"

--- a/fpm/docker-entrypoint.sh
+++ b/fpm/docker-entrypoint.sh
@@ -52,4 +52,14 @@ if [ ! -z "${HIDE_PHP_VERSION}" ]; then
     echo 'expose_php = Off' > $PHP_INI_DIR/conf.d/phpmyadmin-hide-php-version.ini
 fi
 
+if [ ! -z "${PMA_CONFIG_BASE64}" ]; then
+    echo "Adding the custom config.inc.php from base64."
+    echo "${PMA_CONFIG_BASE64}" | base64 -d > /etc/phpmyadmin/config.inc.php
+fi
+
+if [ ! -z "${PMA_USER_CONFIG_BASE64}" ]; then
+    echo "Adding the custom config.user.inc.php from base64."
+    echo "${PMA_USER_CONFIG_BASE64}" | base64 -d > /etc/phpmyadmin/config.user.inc.php
+fi
+
 exec "$@"


### PR DESCRIPTION
Closes: #192

```
>  docker run --rm -p 8080:80 -eUPLOAD_LIMIT=4G -e PMA_CONFIG_BASE64=$(echo '<?php' | base64) -it apache-test:latest bash
Adding the custom config.inc.php from base64.
root@3b14a1239adf:/var/www/html# cat /etc/phpmyadmin/config.inc.php 
<?php
root@3b14a1239adf:/var/www/html# exit
> docker run --rm -p 8080:80 -eUPLOAD_LIMIT=4G -e PMA_USER_CONFIG_BASE64=$(echo '<?php' | base64) -it apache-test:latest bash
Adding the custom config.user.inc.php from base64.
root@449e76dacbed:/var/www/html# cat /etc/phpmyadmin/config.user.inc.php 
<?php
root@449e76dacbed:/var/www/html# exit
```