### PR TITLE
#281 Added tzdata package

### DIFF
--- a/fpm-alpine/Dockerfile
+++ b/fpm-alpine/Dockerfile
@@ -2,7 +2,8 @@ FROM php:7.4-fpm-alpine
 
 # docker-entrypoint.sh dependencies
 RUN apk add --no-cache \
-    bash
+    bash \
+    tzdata
 
 # Install dependencies
 RUN set -ex; \


### PR DESCRIPTION
Added tzdata package so that the TZ env variable is handled correctly.

```bash
docker run --rm -it -e "TZ=Europe/Luxembourg" 5c96a8fcaca0 date
Fri Mar 27 23:15:48 CET 2020
docker run --rm -it -e "TZ=Europe/London" 5c96a8fcaca0 date
Fri Mar 27 22:15:56 GMT 2020
```

Fixes #281 