### PR TITLE
add 'max_input_vars = 10000' to phpmyadmin_misc.ini

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -57,6 +57,7 @@ RUN set -ex; \
         echo 'allow_url_fopen = Off'; \
         echo 'max_execution_time = 600'; \
         echo 'memory_limit = 512M'; \
+        echo 'max_input_vars = 10000'; \
     } > $PHP_INI_DIR/conf.d/phpmyadmin-misc.ini
 
 # Calculate download URL

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -59,6 +59,7 @@ RUN set -ex; \
         echo 'allow_url_fopen = Off'; \
         echo 'max_execution_time = 600'; \
         echo 'memory_limit = 512M'; \
+        echo 'max_input_vars = 10000'; \
     } > $PHP_INI_DIR/conf.d/phpmyadmin-misc.ini
 
 # Calculate download URL

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -59,6 +59,7 @@ RUN set -ex; \
         echo 'allow_url_fopen = Off'; \
         echo 'max_execution_time = 600'; \
         echo 'memory_limit = 512M'; \
+        echo 'max_input_vars = 10000'; \
     } > $PHP_INI_DIR/conf.d/phpmyadmin-misc.ini
 
 # Calculate download URL

--- a/fpm-alpine/Dockerfile
+++ b/fpm-alpine/Dockerfile
@@ -57,6 +57,7 @@ RUN set -ex; \
         echo 'allow_url_fopen = Off'; \
         echo 'max_execution_time = 600'; \
         echo 'memory_limit = 512M'; \
+        echo 'max_input_vars = 10000'; \
     } > $PHP_INI_DIR/conf.d/phpmyadmin-misc.ini
 
 # Calculate download URL

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -59,6 +59,7 @@ RUN set -ex; \
         echo 'allow_url_fopen = Off'; \
         echo 'max_execution_time = 600'; \
         echo 'memory_limit = 512M'; \
+        echo 'max_input_vars = 10000'; \
     } > $PHP_INI_DIR/conf.d/phpmyadmin-misc.ini
 
 # Calculate download URL


### PR DESCRIPTION
default `max_input_vars` value is 1000, and it's often too low for DB with large number of tables export, causing fatal error:
> Fatal error: Uncaught TypeError: Argument 5 passed to PhpMyAdmin\Export::getFilenameAndMimetype() must be of the type string, null given, called in /var/www/html/export.php on line 380 

this PR:
- raises the value of it to 10000
- exposes it in the INI file, so it's easier to edit if anyone desire so