### PR TITLE
Add the possibility to change max_execution_time

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Set the variable ``PMA_ABSOLUTE_URI`` to the fully-qualified path (``https://pma
 * ``PMA_ABSOLUTE_URI`` - define user-facing URI
 * ``HIDE_PHP_VERSION`` - if defined, this option will hide the PHP version (`expose_php = Off`). Set to any value (such as `HIDE_PHP_VERSION=true`).
 * ``UPLOAD_LIMIT`` - if set, this option will override the default value for apache and php-fpm (format as `[0-9+](K,M,G)` default value is 2048K, this will change ``upload_max_filesize`` and ``post_max_size`` values)
+* ``MAX_EXECUTION_TIME`` - if set, will override the maximum execution time in seconds (default 600) for phpMyAdmin ([$cfg['ExecTimeLimit']](https://docs.phpmyadmin.net/en/latest/config.html#cfg_ExecTimeLimit)) and PHP [max_execution_time](https://www.php.net/manual/en/info.configuration.php#ini.max-execution-time) (format as `[0-9+]`)
 * ``PMA_CONFIG_BASE64`` - if set, this option will override the default `config.inc.php` with the base64 decoded contents of the variable
 * ``PMA_USER_CONFIG_BASE64`` - if set, this option will override the default `config.user.inc.php` with the base64 decoded contents of the variable
 

--- a/apache/config.inc.php
+++ b/apache/config.inc.php
@@ -21,7 +21,8 @@ $vars = array(
     'PMA_PMADB',
     'PMA_CONTROLUSER',
     'PMA_CONTROLPASS',
-    'PMA_QUERYHISTORYDB'
+    'PMA_QUERYHISTORYDB',
+    'MAX_EXECUTION_TIME'
 );
 foreach ($vars as $var) {
     $env = getenv($var);
@@ -130,6 +131,10 @@ $i--;
 /* Uploads setup */
 $cfg['UploadDir'] = '';
 $cfg['SaveDir'] = '';
+
+if (isset($_ENV['MAX_EXECUTION_TIME'])) {
+    $cfg['ExecTimeLimit'] = $_ENV['MAX_EXECUTION_TIME'];
+}
 
 /* Include User Defined Settings Hook */
 if (file_exists('/etc/phpmyadmin/config.user.inc.php')) {

--- a/apache/docker-entrypoint.sh
+++ b/apache/docker-entrypoint.sh
@@ -24,6 +24,11 @@ if [ ! -z "${UPLOAD_LIMIT}" ]; then
     echo -e "upload_max_filesize = $UPLOAD_LIMIT\npost_max_size = $UPLOAD_LIMIT\n" > $UPLOAD_LIMIT_INI_FILE
 fi
 
+if [ ! -z "${MAX_EXECUTION_TIME}" ]; then
+    echo "Adjusting the maximum execution time."
+    sed -i "s/^max_execution_time = .*$/max_execution_time = ${MAX_EXECUTION_TIME}/g" $PHP_INI_DIR/conf.d/phpmyadmin-misc.ini
+fi
+
 if [ ! -z "${PMA_CONFIG_BASE64}" ]; then
     echo "Adding the custom config.inc.php from base64."
     echo "${PMA_CONFIG_BASE64}" | base64 -d > /etc/phpmyadmin/config.inc.php

--- a/config.inc.php
+++ b/config.inc.php
@@ -21,7 +21,8 @@ $vars = array(
     'PMA_PMADB',
     'PMA_CONTROLUSER',
     'PMA_CONTROLPASS',
-    'PMA_QUERYHISTORYDB'
+    'PMA_QUERYHISTORYDB',
+    'MAX_EXECUTION_TIME'
 );
 foreach ($vars as $var) {
     $env = getenv($var);
@@ -130,6 +131,10 @@ $i--;
 /* Uploads setup */
 $cfg['UploadDir'] = '';
 $cfg['SaveDir'] = '';
+
+if (isset($_ENV['MAX_EXECUTION_TIME'])) {
+    $cfg['ExecTimeLimit'] = $_ENV['MAX_EXECUTION_TIME'];
+}
 
 /* Include User Defined Settings Hook */
 if (file_exists('/etc/phpmyadmin/config.user.inc.php')) {

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -24,6 +24,11 @@ if [ ! -z "${UPLOAD_LIMIT}" ]; then
     echo -e "upload_max_filesize = $UPLOAD_LIMIT\npost_max_size = $UPLOAD_LIMIT\n" > $UPLOAD_LIMIT_INI_FILE
 fi
 
+if [ ! -z "${MAX_EXECUTION_TIME}" ]; then
+    echo "Adjusting the maximum execution time."
+    sed -i "s/^max_execution_time = .*$/max_execution_time = ${MAX_EXECUTION_TIME}/g" $PHP_INI_DIR/conf.d/phpmyadmin-misc.ini
+fi
+
 if [ ! -z "${PMA_CONFIG_BASE64}" ]; then
     echo "Adding the custom config.inc.php from base64."
     echo "${PMA_CONFIG_BASE64}" | base64 -d > /etc/phpmyadmin/config.inc.php

--- a/fpm-alpine/config.inc.php
+++ b/fpm-alpine/config.inc.php
@@ -21,7 +21,8 @@ $vars = array(
     'PMA_PMADB',
     'PMA_CONTROLUSER',
     'PMA_CONTROLPASS',
-    'PMA_QUERYHISTORYDB'
+    'PMA_QUERYHISTORYDB',
+    'MAX_EXECUTION_TIME'
 );
 foreach ($vars as $var) {
     $env = getenv($var);
@@ -130,6 +131,10 @@ $i--;
 /* Uploads setup */
 $cfg['UploadDir'] = '';
 $cfg['SaveDir'] = '';
+
+if (isset($_ENV['MAX_EXECUTION_TIME'])) {
+    $cfg['ExecTimeLimit'] = $_ENV['MAX_EXECUTION_TIME'];
+}
 
 /* Include User Defined Settings Hook */
 if (file_exists('/etc/phpmyadmin/config.user.inc.php')) {

--- a/fpm-alpine/docker-entrypoint.sh
+++ b/fpm-alpine/docker-entrypoint.sh
@@ -24,6 +24,11 @@ if [ ! -z "${UPLOAD_LIMIT}" ]; then
     echo -e "upload_max_filesize = $UPLOAD_LIMIT\npost_max_size = $UPLOAD_LIMIT\n" > $UPLOAD_LIMIT_INI_FILE
 fi
 
+if [ ! -z "${MAX_EXECUTION_TIME}" ]; then
+    echo "Adjusting the maximum execution time."
+    sed -i "s/^max_execution_time = .*$/max_execution_time = ${MAX_EXECUTION_TIME}/g" $PHP_INI_DIR/conf.d/phpmyadmin-misc.ini
+fi
+
 if [ ! -z "${PMA_CONFIG_BASE64}" ]; then
     echo "Adding the custom config.inc.php from base64."
     echo "${PMA_CONFIG_BASE64}" | base64 -d > /etc/phpmyadmin/config.inc.php

--- a/fpm/config.inc.php
+++ b/fpm/config.inc.php
@@ -21,7 +21,8 @@ $vars = array(
     'PMA_PMADB',
     'PMA_CONTROLUSER',
     'PMA_CONTROLPASS',
-    'PMA_QUERYHISTORYDB'
+    'PMA_QUERYHISTORYDB',
+    'MAX_EXECUTION_TIME'
 );
 foreach ($vars as $var) {
     $env = getenv($var);
@@ -130,6 +131,10 @@ $i--;
 /* Uploads setup */
 $cfg['UploadDir'] = '';
 $cfg['SaveDir'] = '';
+
+if (isset($_ENV['MAX_EXECUTION_TIME'])) {
+    $cfg['ExecTimeLimit'] = $_ENV['MAX_EXECUTION_TIME'];
+}
 
 /* Include User Defined Settings Hook */
 if (file_exists('/etc/phpmyadmin/config.user.inc.php')) {

--- a/fpm/docker-entrypoint.sh
+++ b/fpm/docker-entrypoint.sh
@@ -24,6 +24,11 @@ if [ ! -z "${UPLOAD_LIMIT}" ]; then
     echo -e "upload_max_filesize = $UPLOAD_LIMIT\npost_max_size = $UPLOAD_LIMIT\n" > $UPLOAD_LIMIT_INI_FILE
 fi
 
+if [ ! -z "${MAX_EXECUTION_TIME}" ]; then
+    echo "Adjusting the maximum execution time."
+    sed -i "s/^max_execution_time = .*$/max_execution_time = ${MAX_EXECUTION_TIME}/g" $PHP_INI_DIR/conf.d/phpmyadmin-misc.ini
+fi
+
 if [ ! -z "${PMA_CONFIG_BASE64}" ]; then
     echo "Adding the custom config.inc.php from base64."
     echo "${PMA_CONFIG_BASE64}" | base64 -d > /etc/phpmyadmin/config.inc.php


### PR DESCRIPTION
Make it possible to change the upload_limit without being able to easily change the maximum execution time for php and phpmyadmin, I often ran into problems changing the configs in the docker container.

I can imagine that other users have the same problem, especially with big sql files, slow machines or remote servers and a limited bandwidth.