### PR TITLE
Allow a different Apache port with APACHE_PORT 

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Set the variable ``PMA_ABSOLUTE_URI`` to the fully-qualified path (``https://pma
 * ``MEMORY_LIMIT`` - if set, will override the memory limit (default 512M) for phpMyAdmin ([$cfg['MemoryLimit']](https://docs.phpmyadmin.net/en/latest/config.html#cfg_MemoryLimit)) and PHP [memory_limit](https://www.php.net/manual/en/ini.core.php#ini.memory-limit) (format as `[0-9+](K,M,G)` where K is for Kilobytes, M for Megabytes, G for Gigabytes and 1K = 1024 bytes)
 * ``UPLOAD_LIMIT`` - if set, this option will override the default value for apache and php-fpm (format as `[0-9+](K,M,G)` default value is 2048K, this will change ``upload_max_filesize`` and ``post_max_size`` values)
 * ``HIDE_PHP_VERSION`` - if defined, this option will hide the PHP version (`expose_php = Off`). Set to any value (such as `HIDE_PHP_VERSION=true`).
+* ``APACHE_PORT`` - if defined, this option will change the default Apache port from `80` in case you want it to run on a different port like an unprivileged port.  Set to any port value (such as `APACHE_PORT=8090`)
 
 For usage with Docker secrets, appending ``_FILE`` to the ``PMA_PASSWORD`` environment variable is allowed (it overrides ``PMA_PASSWORD`` if it is set):
 

--- a/apache/docker-entrypoint.sh
+++ b/apache/docker-entrypoint.sh
@@ -28,6 +28,13 @@ if [ ! -z "${PMA_USER_CONFIG_BASE64}" ]; then
     echo "${PMA_USER_CONFIG_BASE64}" | base64 -d > /etc/phpmyadmin/config.user.inc.php
 fi
 
+if [ -n "${APACHE_PORT+x}" ]; then
+    echo "Setting apache port to ${APACHE_PORT}."
+    sed -i "s/VirtualHost \*:80/VirtualHost \*:${APACHE_PORT}/" /etc/apache2/sites-enabled/000-default.conf
+    sed -i "s/Listen 80/Listen ${APACHE_PORT}/" /etc/apache2/ports.conf
+    apachectl configtest
+fi
+
 get_docker_secret() {
     local env_var="${1}"
     local env_var_file="${env_var}_FILE"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -28,6 +28,13 @@ if [ ! -z "${PMA_USER_CONFIG_BASE64}" ]; then
     echo "${PMA_USER_CONFIG_BASE64}" | base64 -d > /etc/phpmyadmin/config.user.inc.php
 fi
 
+if [ -n "${APACHE_PORT+x}" ]; then
+    echo "Setting apache port to ${APACHE_PORT}."
+    sed -i "s/VirtualHost \*:80/VirtualHost \*:${APACHE_PORT}/" /etc/apache2/sites-enabled/000-default.conf
+    sed -i "s/Listen 80/Listen ${APACHE_PORT}/" /etc/apache2/ports.conf
+    apachectl configtest
+fi
+
 get_docker_secret() {
     local env_var="${1}"
     local env_var_file="${env_var}_FILE"


### PR DESCRIPTION
To deal with both #340 and #187, this PR allows for a new Environment variable `APACHE_PORT` to change the default port from `80` to something user defined. If unset, it remains using port 80

Fixes: #340