### PR TITLE
Updating alpine for CI job

### DIFF
--- a/testing/Dockerfile
+++ b/testing/Dockerfile
@@ -1,6 +1,6 @@
 # Testing image for phpMyAdmin
 
-FROM alpine:3.12
+FROM alpine:3.13
 
 # Install test dependencies
 RUN set -ex; \


### PR DESCRIPTION
I noticed in https://github.com/phpmyadmin/docker/runs/6818320857?check_suite_focus=true that CI was failing to pull `alpine:3.12` from https://github.com/docker-library/official-images. I looked at https://github.com/docker-library/official-images/blob/master/library/alpine and noticed that `3.13` is the oldest listed. I figured I could take a moment to see if this would fix it.