### PR TITLE
Add ENV PMA_UPLOADDIR and PMA_SAVEDIR ENVs

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ Set the variable ``PMA_ABSOLUTE_URI`` to the fully-qualified path (``https://pma
 * ``UPLOAD_LIMIT`` - if set, this option will override the default value for apache and php-fpm (format as `[0-9+](K,M,G)` default value is 2048K, this will change ``upload_max_filesize`` and ``post_max_size`` values)
 * ``HIDE_PHP_VERSION`` - if defined, this option will hide the PHP version (`expose_php = Off`). Set to any value (such as `HIDE_PHP_VERSION=true`).
 * ``APACHE_PORT`` - if defined, this option will change the default Apache port from `80` in case you want it to run on a different port like an unprivileged port.  Set to any port value (such as `APACHE_PORT=8090`)
+* ``PMA_UPLOADDIR`` - if defined, this option will set the name of the webserver directory where imported files can be saved to be available to import  ([$cfg['UploadDir']](https://docs.phpmyadmin.net/en/latest/config.html#cfg_UploadDir))
+* ``PMA_SAVEDIR`` - if defined, this option will set the name of the webserver directory where exported files will be saved ([$cfg['SaveDir']](https://docs.phpmyadmin.net/en/latest/config.html#cfg_SaveDir)) 
 
 For usage with Docker secrets, appending ``_FILE`` to the ``PMA_PASSWORD`` environment variable is allowed (it overrides ``PMA_PASSWORD`` if it is set):
 

--- a/README.md
+++ b/README.md
@@ -165,8 +165,8 @@ Set the variable ``PMA_ABSOLUTE_URI`` to the fully-qualified path (``https://pma
 * ``UPLOAD_LIMIT`` - if set, this option will override the default value for apache and php-fpm (format as `[0-9+](K,M,G)` default value is 2048K, this will change ``upload_max_filesize`` and ``post_max_size`` values)
 * ``HIDE_PHP_VERSION`` - if defined, this option will hide the PHP version (`expose_php = Off`). Set to any value (such as `HIDE_PHP_VERSION=true`).
 * ``APACHE_PORT`` - if defined, this option will change the default Apache port from `80` in case you want it to run on a different port like an unprivileged port.  Set to any port value (such as `APACHE_PORT=8090`)
-* ``PMA_UPLOADDIR`` - if defined, this option will set the name of the webserver directory where imported files can be saved to be available to import  ([$cfg['UploadDir']](https://docs.phpmyadmin.net/en/latest/config.html#cfg_UploadDir))
-* ``PMA_SAVEDIR`` - if defined, this option will set the name of the webserver directory where exported files will be saved ([$cfg['SaveDir']](https://docs.phpmyadmin.net/en/latest/config.html#cfg_SaveDir)) 
+* ``PMA_UPLOADDIR`` - if defined, this option will set the path where imported files can be saved to be available to import ([$cfg['UploadDir']](https://docs.phpmyadmin.net/en/latest/config.html#cfg_UploadDir))
+* ``PMA_SAVEDIR`` - if defined, this option will set the path where exported files will be saved ([$cfg['SaveDir']](https://docs.phpmyadmin.net/en/latest/config.html#cfg_SaveDir)) 
 
 For usage with Docker secrets, appending ``_FILE`` to the ``PMA_PASSWORD`` environment variable is allowed (it overrides ``PMA_PASSWORD`` if it is set):
 

--- a/config.inc.php
+++ b/config.inc.php
@@ -25,6 +25,8 @@ $vars = [
     'PMA_QUERYHISTORYMAX',
     'MAX_EXECUTION_TIME',
     'MEMORY_LIMIT',
+    'PMA_UPLOADDIR',
+    'PMA_SAVEDIR',
 ];
 
 foreach ($vars as $var) {
@@ -137,8 +139,13 @@ for ($i = 1; isset($sockets[$i - 1]); $i++) {
 $i--;
 
 /* Uploads setup */
-$cfg['UploadDir'] = '';
-$cfg['SaveDir'] = '';
+if (isset($_ENV['PMA_UPLOADDIR'])) {
+    $cfg['UploadDir'] = trim($_ENV['PMA_UPLOADDIR']);
+}
+
+if (isset($_ENV['PMA_SAVEDIR'])) {
+    $cfg['SaveDir'] = trim($_ENV['PMA_SAVEDIR']);
+}
 
 if (isset($_ENV['MAX_EXECUTION_TIME'])) {
     $cfg['ExecTimeLimit'] = $_ENV['MAX_EXECUTION_TIME'];

--- a/config.inc.php
+++ b/config.inc.php
@@ -140,11 +140,11 @@ $i--;
 
 /* Uploads setup */
 if (isset($_ENV['PMA_UPLOADDIR'])) {
-    $cfg['UploadDir'] = trim($_ENV['PMA_UPLOADDIR']);
+    $cfg['UploadDir'] = $_ENV['PMA_UPLOADDIR'];
 }
 
 if (isset($_ENV['PMA_SAVEDIR'])) {
-    $cfg['SaveDir'] = trim($_ENV['PMA_SAVEDIR']);
+    $cfg['SaveDir'] = $_ENV['PMA_SAVEDIR'];
 }
 
 if (isset($_ENV['MAX_EXECUTION_TIME'])) {


### PR DESCRIPTION
When hosting this image on an Azure hosted container instance, I can mount an Azure FileShare to a local path for uploads but I can't add custom file to the local volume to set the configuration.

This PR adds support setting the UploadDir and SaveDir through environment variables.