### PR TITLE
Fix #133 - Add `TZ` env var to change PHP `date.timezone`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add support for ENVs `PMA_UPLOADDIR` and `PMA_SAVEDIR` (#384)
 - Fixed a bug with `APACHE_PORT` ENV on container restart (#381)
 - Update to PHP 8.1 (#393)
+- Add support for ENV `TZ`
 
 ## [5.1.4] - 2022-05-11
 

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -41,6 +41,7 @@ RUN set -ex; \
 ENV MAX_EXECUTION_TIME 600
 ENV MEMORY_LIMIT 512M
 ENV UPLOAD_LIMIT 2048K
+ENV TZ UTC
 RUN set -ex; \
     \
     { \
@@ -63,6 +64,7 @@ RUN set -ex; \
         echo 'memory_limit=${MEMORY_LIMIT}'; \
         echo 'post_max_size=${UPLOAD_LIMIT}'; \
         echo 'upload_max_filesize=${UPLOAD_LIMIT}'; \
+        echo 'date.timezone=${TZ}'; \
     } > $PHP_INI_DIR/conf.d/phpmyadmin-misc.ini
 
 # Calculate download URL

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -43,6 +43,7 @@ RUN set -ex; \
 ENV MAX_EXECUTION_TIME 600
 ENV MEMORY_LIMIT 512M
 ENV UPLOAD_LIMIT 2048K
+ENV TZ UTC
 RUN set -ex; \
     \
     { \
@@ -65,6 +66,7 @@ RUN set -ex; \
         echo 'memory_limit=${MEMORY_LIMIT}'; \
         echo 'post_max_size=${UPLOAD_LIMIT}'; \
         echo 'upload_max_filesize=${UPLOAD_LIMIT}'; \
+        echo 'date.timezone=${TZ}'; \
     } > $PHP_INI_DIR/conf.d/phpmyadmin-misc.ini
 
 # Calculate download URL

--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ Set the variable ``PMA_ABSOLUTE_URI`` to the fully-qualified path (``https://pma
 * ``MAX_EXECUTION_TIME`` - if set, will override the maximum execution time in seconds (default 600) for phpMyAdmin ([$cfg['ExecTimeLimit']](https://docs.phpmyadmin.net/en/latest/config.html#cfg_ExecTimeLimit)) and PHP [max_execution_time](https://www.php.net/manual/en/info.configuration.php#ini.max-execution-time) (format as `[0-9+]`)
 * ``MEMORY_LIMIT`` - if set, will override the memory limit (default 512M) for phpMyAdmin ([$cfg['MemoryLimit']](https://docs.phpmyadmin.net/en/latest/config.html#cfg_MemoryLimit)) and PHP [memory_limit](https://www.php.net/manual/en/ini.core.php#ini.memory-limit) (format as `[0-9+](K,M,G)` where K is for Kilobytes, M for Megabytes, G for Gigabytes and 1K = 1024 bytes)
 * ``UPLOAD_LIMIT`` - if set, this option will override the default value for apache and php-fpm (format as `[0-9+](K,M,G)` default value is 2048K, this will change ``upload_max_filesize`` and ``post_max_size`` values)
+* ``TZ`` - if defined, this option will change the default PHP `date.timezone` from `UTC`. See [documentation](https://www.php.net/manual/en/timezones.php) for supported values.
 * ``HIDE_PHP_VERSION`` - if defined, this option will hide the PHP version (`expose_php = Off`). Set to any value (such as `HIDE_PHP_VERSION=true`).
 * ``APACHE_PORT`` - if defined, this option will change the default Apache port from `80` in case you want it to run on a different port like an unprivileged port.  Set to any port value (such as `APACHE_PORT=8090`)
 

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -43,6 +43,7 @@ RUN set -ex; \
 ENV MAX_EXECUTION_TIME 600
 ENV MEMORY_LIMIT 512M
 ENV UPLOAD_LIMIT 2048K
+ENV TZ UTC
 RUN set -ex; \
     \
     { \
@@ -65,6 +66,7 @@ RUN set -ex; \
         echo 'memory_limit=${MEMORY_LIMIT}'; \
         echo 'post_max_size=${UPLOAD_LIMIT}'; \
         echo 'upload_max_filesize=${UPLOAD_LIMIT}'; \
+        echo 'date.timezone=${TZ}'; \
     } > $PHP_INI_DIR/conf.d/phpmyadmin-misc.ini
 
 # Calculate download URL

--- a/fpm-alpine/Dockerfile
+++ b/fpm-alpine/Dockerfile
@@ -41,6 +41,7 @@ RUN set -ex; \
 ENV MAX_EXECUTION_TIME 600
 ENV MEMORY_LIMIT 512M
 ENV UPLOAD_LIMIT 2048K
+ENV TZ UTC
 RUN set -ex; \
     \
     { \
@@ -63,6 +64,7 @@ RUN set -ex; \
         echo 'memory_limit=${MEMORY_LIMIT}'; \
         echo 'post_max_size=${UPLOAD_LIMIT}'; \
         echo 'upload_max_filesize=${UPLOAD_LIMIT}'; \
+        echo 'date.timezone=${TZ}'; \
     } > $PHP_INI_DIR/conf.d/phpmyadmin-misc.ini
 
 # Calculate download URL

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -43,6 +43,7 @@ RUN set -ex; \
 ENV MAX_EXECUTION_TIME 600
 ENV MEMORY_LIMIT 512M
 ENV UPLOAD_LIMIT 2048K
+ENV TZ UTC
 RUN set -ex; \
     \
     { \
@@ -65,6 +66,7 @@ RUN set -ex; \
         echo 'memory_limit=${MEMORY_LIMIT}'; \
         echo 'post_max_size=${UPLOAD_LIMIT}'; \
         echo 'upload_max_filesize=${UPLOAD_LIMIT}'; \
+        echo 'date.timezone=${TZ}'; \
     } > $PHP_INI_DIR/conf.d/phpmyadmin-misc.ini
 
 # Calculate download URL


### PR DESCRIPTION
this allows date pickers in UI to pick up the right time

Fixes: #133