### PR TITLE
add netcat to provide healthcheck

### DIFF
--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -119,6 +119,16 @@ RUN set -ex; \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
     rm -rf /var/lib/apt/lists/*
 
+# Install netcat to support healthcheck
+RUN set -ex; \
+    \
+    savedAptMark="$(apt-mark showmanual)"; \
+    \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        netcat \
+    ;
+
 # Copy configuration
 COPY config.inc.php /etc/phpmyadmin/config.inc.php
 

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -119,6 +119,16 @@ RUN set -ex; \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
     rm -rf /var/lib/apt/lists/*
 
+# Install netcat to support healthcheck
+RUN set -ex; \
+    \
+    savedAptMark="$(apt-mark showmanual)"; \
+    \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        netcat \
+    ;
+
 # Copy configuration
 COPY config.inc.php /etc/phpmyadmin/config.inc.php
 


### PR DESCRIPTION
This PR adds netcat to have options to do health check on running container.

Example on terminal
```bash
root@phpmyadmin:/var/www/html# nc -vz 127.0.0.1 80
Connection to 127.0.0.1 80 port [tcp/*] succeeded!
```

Example on docker compose using `docker-compose.yml` from this project as base:
```yaml
phpmyadmin:
    image: phpmyadmin
    container_name: phpmyadmin
    environment:
     - PMA_ARBITRARY=1
    restart: always
    ports:
     - 8080:80
    volumes:
     - /sessions
    healthcheck:
        test: ["CMD", "nc", "-vz", "127.0.0.1", "80"]
        interval: 3s
        timeout: 1s
        retries: 20
```