### PR TITLE
Update to PHP 8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased] - YYYY-MM-DD
 
 - Add `TZ` env var to change PHP `date.timezone` (#133)
+- Update to PHP 8.2
 
 ## [5.2.1] - 2023-02-08
 

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -1,4 +1,4 @@
-FROM php:8.1-%%VARIANT%%
+FROM php:8.2-%%VARIANT%%
 
 # docker-entrypoint.sh dependencies
 RUN apk add --no-cache \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -1,4 +1,4 @@
-FROM php:8.1-%%VARIANT%%
+FROM php:8.2-%%VARIANT%%
 
 # Install dependencies
 RUN set -ex; \

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1-apache
+FROM php:8.2-apache
 
 # Install dependencies
 RUN set -ex; \

--- a/fpm-alpine/Dockerfile
+++ b/fpm-alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1-fpm-alpine
+FROM php:8.2-fpm-alpine
 
 # docker-entrypoint.sh dependencies
 RUN apk add --no-cache \

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1-fpm
+FROM php:8.2-fpm
 
 # Install dependencies
 RUN set -ex; \


### PR DESCRIPTION
PHP 8.2 has been generally available on 2022-12-08 and has had quite a few patch releases. It can be expected to be pretty stable. Active support for PHP 8.1 is ending 2023-11-25.

I have run the end-to-end tests with `make run-tests`, all have passed.

Previous upgrade to PHP 8.1: d1f327e4627ed01454438844a2c96f075bf2f1e8