### PR TITLE
add extension bcmath for 2nd factor authentication

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -25,6 +25,7 @@ RUN set -ex; \
         mysqli \
         opcache \
         zip \
+        bcmath \
     ; \
     \
     runDeps="$( \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -23,6 +23,7 @@ RUN set -ex; \
         mysqli \
         opcache \
         zip \
+        bcmath \
     ; \
     \
     apt-mark auto '.*' > /dev/null; \


### PR DESCRIPTION
`GMP` or `bcmath` is required when second factor authentication is enabled.