### PR TITLE
Fix for debian 12 issue (#416) that caused libraries for extensions to be uninstalled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update to PHP 8.2 (#411)
 - Add back a `/sessions` volume for sessions persistence (#399)
 - Support adding custom configurations in `/etc/phpmyadmin/conf.d` (#401)
+- Fix for debian 12 issue (#416) that caused libraries for extensions to be uninstalled
 
 ## [5.2.1] - 2023-02-08
 

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -27,8 +27,10 @@ RUN set -ex; \
     \
     apt-mark auto '.*' > /dev/null; \
     apt-mark manual $savedAptMark; \
-    ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+    extdir="$(php -r 'echo ini_get("extension_dir");')"; \
+    ldd "$extdir"/*.so \
         | awk '/=>/ { print $3 }' \
+        | awk '{print $1} {system("realpath " $1)}' \
         | sort -u \
         | xargs -r dpkg-query -S \
         | cut -d: -f1 \
@@ -36,7 +38,8 @@ RUN set -ex; \
         | xargs -rt apt-mark manual; \
     \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/*; \
+    ldd "$extdir"/*.so | grep -qzv "=> not found";
 
 # set recommended PHP.ini settings
 # see https://secure.php.net/manual/en/opcache.installation.php

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -39,7 +39,8 @@ RUN set -ex; \
     \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
     rm -rf /var/lib/apt/lists/*; \
-    ldd "$extdir"/*.so | grep -qzv "=> not found";
+    ldd "$extdir"/*.so | grep -qzv "=> not found" || (echo "Sanity check failed: missing libraries:"; ldd "$extdir"/*.so | grep " => not found"; exit 1); \
+    ldd "$extdir"/*.so | grep -q "libzip.so.* => .*/libzip.so.*" || (echo "Sanity check failed: libzip.so is not referenced"; ldd "$extdir"/*.so; exit 1);
 
 # set recommended PHP.ini settings
 # see https://secure.php.net/manual/en/opcache.installation.php

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -27,7 +27,8 @@ RUN set -ex; \
     \
     apt-mark auto '.*' > /dev/null; \
     apt-mark manual $savedAptMark; \
-    ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+    extdir="$(php -r 'echo ini_get("extension_dir");')"; \
+    ldd "$extdir"/*.so \
         | awk '/=>/ { print $3 }' \
         | sort -u \
         | xargs -r dpkg-query -S \
@@ -36,7 +37,8 @@ RUN set -ex; \
         | xargs -rt apt-mark manual; \
     \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/*; \
+    ldd "$extdir"/*.so | grep -qzv "=> not found";
 
 # set recommended PHP.ini settings
 # see https://secure.php.net/manual/en/opcache.installation.php

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -30,6 +30,7 @@ RUN set -ex; \
     extdir="$(php -r 'echo ini_get("extension_dir");')"; \
     ldd "$extdir"/*.so \
         | awk '/=>/ { print $3 }' \
+        | awk '{print $1} {system("realpath " $1)}' \
         | sort -u \
         | xargs -r dpkg-query -S \
         | cut -d: -f1 \
@@ -38,7 +39,8 @@ RUN set -ex; \
     \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
     rm -rf /var/lib/apt/lists/*; \
-    ldd "$extdir"/*.so | grep -qzv "=> not found";
+    ldd "$extdir"/*.so | grep -qzv "=> not found" || (echo "Sanity check failed: missing libraries:"; ldd "$extdir"/*.so | grep " => not found"; exit 1); \
+    ldd "$extdir"/*.so | grep -q "libzip.so.* => .*/libzip.so.*" || (echo "Sanity check failed: libzip.so is not referenced"; ldd "$extdir"/*.so; exit 1);
 
 # set recommended PHP.ini settings
 # see https://secure.php.net/manual/en/opcache.installation.php

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -27,7 +27,8 @@ RUN set -ex; \
     \
     apt-mark auto '.*' > /dev/null; \
     apt-mark manual $savedAptMark; \
-    ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+    extdir="$(php -r 'echo ini_get("extension_dir");')"; \
+    ldd "$extdir"/*.so \
         | awk '/=>/ { print $3 }' \
         | sort -u \
         | xargs -r dpkg-query -S \
@@ -36,7 +37,8 @@ RUN set -ex; \
         | xargs -rt apt-mark manual; \
     \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/*; \
+    ldd "$extdir"/*.so | grep -qzv "=> not found";
 
 # set recommended PHP.ini settings
 # see https://secure.php.net/manual/en/opcache.installation.php

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -30,6 +30,7 @@ RUN set -ex; \
     extdir="$(php -r 'echo ini_get("extension_dir");')"; \
     ldd "$extdir"/*.so \
         | awk '/=>/ { print $3 }' \
+        | awk '{print $1} {system("realpath " $1)}' \
         | sort -u \
         | xargs -r dpkg-query -S \
         | cut -d: -f1 \
@@ -38,7 +39,8 @@ RUN set -ex; \
     \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
     rm -rf /var/lib/apt/lists/*; \
-    ldd "$extdir"/*.so | grep -qzv "=> not found";
+    ldd "$extdir"/*.so | grep -qzv "=> not found" || (echo "Sanity check failed: missing libraries:"; ldd "$extdir"/*.so | grep " => not found"; exit 1); \
+    ldd "$extdir"/*.so | grep -q "libzip.so.* => .*/libzip.so.*" || (echo "Sanity check failed: libzip.so is not referenced"; ldd "$extdir"/*.so; exit 1);
 
 # set recommended PHP.ini settings
 # see https://secure.php.net/manual/en/opcache.installation.php


### PR DESCRIPTION
This also adds a test that makes sure all extension libraries are installed (buld fails if `ldd` outputs a line with ` => not found`)

Note: the extdir variable is needed because if we execute php after the libraries are removed it will print warnings causing the ldd command to fail

Fixes: #416