### PR TITLE
Fix Permissions of config.secret.inc.php

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -7,6 +7,7 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 \$cfg['blowfish_secret'] = '$(tr -dc 'a-zA-Z0-9~!@#$%^&*_()+}{?></";.,[]=-' < /dev/urandom | fold -w 32 | head -n 1)';
 EOT
     fi
+    chgrp www-data /etc/phpmyadmin/config.secret.inc.php
 
     if [ ! -f /etc/phpmyadmin/config.user.inc.php ]; then
         touch /etc/phpmyadmin/config.user.inc.php


### PR DESCRIPTION
For Docker in rootless-mode having the default umask of Docker set to 0007, the file will get created readable only to root.

Changed the ownership of that file to be readable by www-data.

Adresses #187

See details in Comment https://github.com/phpmyadmin/docker/issues/187#issuecomment-1872177089