### PR TITLE
Enabled remoteip mod for Apache

### DIFF
--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -127,6 +127,7 @@ RUN set -ex; \
     sed -i "s@'configFile' => .*@'configFile' => '/etc/phpmyadmin/config.inc.php',@" /var/www/html/libraries/vendor_config.php; \
     grep -q -F "'configFile' => '/etc/phpmyadmin/config.inc.php'," /var/www/html/libraries/vendor_config.php; \
     php -l /var/www/html/libraries/vendor_config.php; \
+    a2enmod remoteip; \
     \
     apt-mark auto '.*' > /dev/null; \
     apt-mark manual $savedAptMark; \


### PR DESCRIPTION
I've enabled the remoiteip mod for Apache during build time. The reason is that now the remote ip address is posted to the log file if phpmyadmin is running behind a proxy - with the correct proxy configuration.
This can then be used i.e. with fail2ban to track and block IP addresses executing bruteforce attacks
![grafik](https://github.com/phpmyadmin/docker/assets/71716485/0508adbb-98cf-4415-9733-740601421f83)
