### PR TITLE
Enable SSL for all server

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ In order to keep your sessions active between container updates you will need to
 
 ## Connect over SSL with backend
 
-Set the variable ``PMA_SSL`` to '1' and enable ssl usage from phpmyadmin to mysql server. The default value is 0. Variable ``PMA_SSLS`` can be used as a comma seperated sequence of 0 and 1 where multiple hosts are mentioned. Values order must follow the ``PMA_HOSTS`` and will be computed accordingly.
+Set the variable ``PMA_SSL`` to '1' and enable ssl usage from phpmyadmin to mysql server. The default value is 0. Variable ``PMA_SSLS`` can be used as a comma seperated sequence of `0` and `1` where multiple hosts are mentioned. Values order must follow the ``PMA_HOSTS`` and will be computed accordingly.
 
 ```sh
 docker run --name phpmyadmin -d -e PMA_HOSTS=sslhost -e PMA_SSL=1 -p 8080:80 phpmyadmin:latest
@@ -203,13 +203,11 @@ docker run --name phpmyadmin -d -e PMA_HOSTS='sslhost,nosslhost' -e PMA_SSLS='1,
 
 For usage with Docker secrets, appending ``_FILE`` to the ``PMA_PASSWORD`` environment variable is allowed (it overrides ``PMA_PASSWORD`` if it is set):
 
-* ``PMA_SSL`` - define ssl usage for MySQL server
-
-* ``PMA_SSLS`` - comma separated list of 0 and 1 defining ssl usage for corresponding MySQL servers
-
 ```sh
 docker run --name phpmyadmin -d -e PMA_PASSWORD_FILE=/run/secrets/db_password.txt -p 8080:80 phpmyadmin:latest
 ```
+* ``PMA_SSL`` - define ssl usage for MySQL server
+* ``PMA_SSLS`` - comma separated list of 0 and 1 defining ssl usage for corresponding MySQL servers
 
 #### Variables that can be read from a file using ``_FILE``
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,18 @@ In order to keep your sessions active between container updates you will need to
 -v /some/local/directory/sessions:/sessions:rw
 ```
 
+## Connect over SSL with backend
+
+Set the variable ``PMA_SSL`` to '1' and enable ssl usage from phpmyadmin to mysql server. The default value is 0. Variable ``PMA_SSLS`` can be used as a comma seperated sequence of 0 and 1 where multiple hosts are mentioned. Values order must follow the ``PMA_HOSTS`` and will be computed accordingly.
+
+```sh
+docker run --name phpmyadmin -d -e PMA_HOSTS=sslhost -e PMA_SSL=1 -p 8080:80 phpmyadmin:latest
+```
+
+```sh
+docker run --name phpmyadmin -d -e PMA_HOSTS='sslhost,nosslhost' -e PMA_SSLS='1,0' -p 8080:80 phpmyadmin:latest
+```
+
 ## Environment variables summary
 
 * ``PMA_ARBITRARY`` - when set to 1 connection to the arbitrary server will be allowed
@@ -191,6 +203,10 @@ In order to keep your sessions active between container updates you will need to
 
 For usage with Docker secrets, appending ``_FILE`` to the ``PMA_PASSWORD`` environment variable is allowed (it overrides ``PMA_PASSWORD`` if it is set):
 
+* ``PMA_SSL`` - define ssl usage for MySQL server
+
+* ``PMA_SSLS`` - comma separated list of 0 and 1 defining ssl usage for corresponding MySQL servers
+
 ```sh
 docker run --name phpmyadmin -d -e PMA_PASSWORD_FILE=/run/secrets/db_password.txt -p 8080:80 phpmyadmin:latest
 ```
@@ -206,6 +222,8 @@ docker run --name phpmyadmin -d -e PMA_PASSWORD_FILE=/run/secrets/db_password.tx
 - `PMA_CONTROLHOST`
 - `PMA_CONTROLUSER`
 - `PMA_CONTROLPASS`
+- `PMA_SSL`
+- `PMA_SSLS`
 
 ## Run the E2E tests for this docker image
 

--- a/apache/config.inc.php
+++ b/apache/config.inc.php
@@ -77,6 +77,7 @@ if (! empty($_ENV['PMA_SOCKET'])) {
 
 /* Server settings */
 for ($i = 1; isset($hosts[$i - 1]); $i++) {
+    $cfg['Servers'][$i]['ssl'] = true;
     $cfg['Servers'][$i]['host'] = $hosts[$i - 1];
     if (isset($verbose[$i - 1])) {
         $cfg['Servers'][$i]['verbose'] = $verbose[$i - 1];

--- a/apache/config.inc.php
+++ b/apache/config.inc.php
@@ -27,6 +27,8 @@ $vars = [
     'MEMORY_LIMIT',
     'PMA_UPLOADDIR',
     'PMA_SAVEDIR',
+    'PMA_SSL',
+    'PMA_SSLS',
 ];
 
 foreach ($vars as $var) {
@@ -63,10 +65,12 @@ if (! empty($_ENV['PMA_HOST'])) {
     $hosts = [$_ENV['PMA_HOST']];
     $verbose = [$_ENV['PMA_VERBOSE']];
     $ports = [$_ENV['PMA_PORT']];
+    $ssls = [$_ENV['PMA_SSL']];
 } elseif (! empty($_ENV['PMA_HOSTS'])) {
     $hosts = array_map('trim', explode(',', $_ENV['PMA_HOSTS']));
     $verbose = array_map('trim', explode(',', $_ENV['PMA_VERBOSES']));
     $ports = array_map('trim', explode(',', $_ENV['PMA_PORTS']));
+    $ssls = array_map('trim', explode(',', $_ENV['PMA_SSLS']));
 }
 
 if (! empty($_ENV['PMA_SOCKET'])) {
@@ -77,7 +81,9 @@ if (! empty($_ENV['PMA_SOCKET'])) {
 
 /* Server settings */
 for ($i = 1; isset($hosts[$i - 1]); $i++) {
-    $cfg['Servers'][$i]['ssl'] = true;
+    if (isset($ssls[$i - 1]) && $ssls[$i - 1] === '1') {
+        $cfg['Servers'][$i]['ssl'] = $ssls[$i - 1];
+    }
     $cfg['Servers'][$i]['host'] = $hosts[$i - 1];
     if (isset($verbose[$i - 1])) {
         $cfg['Servers'][$i]['verbose'] = $verbose[$i - 1];

--- a/apache/docker-entrypoint.sh
+++ b/apache/docker-entrypoint.sh
@@ -55,6 +55,8 @@ get_docker_secret MYSQL_ROOT_PASSWORD
 get_docker_secret MYSQL_PASSWORD
 get_docker_secret PMA_HOSTS
 get_docker_secret PMA_HOST
+get_docker_secret PMA_SSL
+get_docker_secret PMA_SSLS
 get_docker_secret PMA_CONTROLHOST
 get_docker_secret PMA_CONTROLUSER
 get_docker_secret PMA_CONTROLPASS

--- a/apache/docker-entrypoint.sh
+++ b/apache/docker-entrypoint.sh
@@ -55,10 +55,10 @@ get_docker_secret MYSQL_ROOT_PASSWORD
 get_docker_secret MYSQL_PASSWORD
 get_docker_secret PMA_HOSTS
 get_docker_secret PMA_HOST
-get_docker_secret PMA_SSL
-get_docker_secret PMA_SSLS
 get_docker_secret PMA_CONTROLHOST
 get_docker_secret PMA_CONTROLUSER
 get_docker_secret PMA_CONTROLPASS
+get_docker_secret PMA_SSL
+get_docker_secret PMA_SSLS
 
 exec "$@"

--- a/config.inc.php
+++ b/config.inc.php
@@ -27,6 +27,8 @@ $vars = [
     'MEMORY_LIMIT',
     'PMA_UPLOADDIR',
     'PMA_SAVEDIR',
+    'PMA_SSL',
+    'PMA_SSLS',
 ];
 
 foreach ($vars as $var) {
@@ -63,10 +65,12 @@ if (! empty($_ENV['PMA_HOST'])) {
     $hosts = [$_ENV['PMA_HOST']];
     $verbose = [$_ENV['PMA_VERBOSE']];
     $ports = [$_ENV['PMA_PORT']];
+    $ssls = [$_ENV['PMA_SSL']];
 } elseif (! empty($_ENV['PMA_HOSTS'])) {
     $hosts = array_map('trim', explode(',', $_ENV['PMA_HOSTS']));
     $verbose = array_map('trim', explode(',', $_ENV['PMA_VERBOSES']));
     $ports = array_map('trim', explode(',', $_ENV['PMA_PORTS']));
+    $ssls = array_map('trim', explode(',', $_ENV['PMA_SSLS']));
 }
 
 if (! empty($_ENV['PMA_SOCKET'])) {
@@ -77,6 +81,9 @@ if (! empty($_ENV['PMA_SOCKET'])) {
 
 /* Server settings */
 for ($i = 1; isset($hosts[$i - 1]); $i++) {
+    if (isset($ssls[$i - 1]) && $ssls[$i - 1] === '1') {
+        $cfg['Servers'][$i]['ssl'] = $ssls[$i - 1];
+    }
     $cfg['Servers'][$i]['host'] = $hosts[$i - 1];
     if (isset($verbose[$i - 1])) {
         $cfg['Servers'][$i]['verbose'] = $verbose[$i - 1];

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -58,5 +58,7 @@ get_docker_secret PMA_HOST
 get_docker_secret PMA_CONTROLHOST
 get_docker_secret PMA_CONTROLUSER
 get_docker_secret PMA_CONTROLPASS
+get_docker_secret PMA_SSL
+get_docker_secret PMA_SSLS
 
 exec "$@"

--- a/fpm-alpine/config.inc.php
+++ b/fpm-alpine/config.inc.php
@@ -27,6 +27,8 @@ $vars = [
     'MEMORY_LIMIT',
     'PMA_UPLOADDIR',
     'PMA_SAVEDIR',
+    'PMA_SSL',
+    'PMA_SSLS',
 ];
 
 foreach ($vars as $var) {
@@ -63,10 +65,12 @@ if (! empty($_ENV['PMA_HOST'])) {
     $hosts = [$_ENV['PMA_HOST']];
     $verbose = [$_ENV['PMA_VERBOSE']];
     $ports = [$_ENV['PMA_PORT']];
+    $ssls = [$_ENV['PMA_SSL']];
 } elseif (! empty($_ENV['PMA_HOSTS'])) {
     $hosts = array_map('trim', explode(',', $_ENV['PMA_HOSTS']));
     $verbose = array_map('trim', explode(',', $_ENV['PMA_VERBOSES']));
     $ports = array_map('trim', explode(',', $_ENV['PMA_PORTS']));
+    $ssls = array_map('trim', explode(',', $_ENV['PMA_SSLS']));
 }
 
 if (! empty($_ENV['PMA_SOCKET'])) {
@@ -77,6 +81,9 @@ if (! empty($_ENV['PMA_SOCKET'])) {
 
 /* Server settings */
 for ($i = 1; isset($hosts[$i - 1]); $i++) {
+    if (isset($ssls[$i - 1]) && $ssls[$i - 1] === '1') {
+        $cfg['Servers'][$i]['ssl'] = $ssls[$i - 1];
+    }
     $cfg['Servers'][$i]['host'] = $hosts[$i - 1];
     if (isset($verbose[$i - 1])) {
         $cfg['Servers'][$i]['verbose'] = $verbose[$i - 1];

--- a/fpm-alpine/docker-entrypoint.sh
+++ b/fpm-alpine/docker-entrypoint.sh
@@ -50,5 +50,7 @@ get_docker_secret PMA_HOST
 get_docker_secret PMA_CONTROLHOST
 get_docker_secret PMA_CONTROLUSER
 get_docker_secret PMA_CONTROLPASS
+get_docker_secret PMA_SSL
+get_docker_secret PMA_SSLS
 
 exec "$@"

--- a/fpm/config.inc.php
+++ b/fpm/config.inc.php
@@ -27,6 +27,8 @@ $vars = [
     'MEMORY_LIMIT',
     'PMA_UPLOADDIR',
     'PMA_SAVEDIR',
+    'PMA_SSL',
+    'PMA_SSLS',
 ];
 
 foreach ($vars as $var) {
@@ -63,10 +65,12 @@ if (! empty($_ENV['PMA_HOST'])) {
     $hosts = [$_ENV['PMA_HOST']];
     $verbose = [$_ENV['PMA_VERBOSE']];
     $ports = [$_ENV['PMA_PORT']];
+    $ssls = [$_ENV['PMA_SSL']];
 } elseif (! empty($_ENV['PMA_HOSTS'])) {
     $hosts = array_map('trim', explode(',', $_ENV['PMA_HOSTS']));
     $verbose = array_map('trim', explode(',', $_ENV['PMA_VERBOSES']));
     $ports = array_map('trim', explode(',', $_ENV['PMA_PORTS']));
+    $ssls = array_map('trim', explode(',', $_ENV['PMA_SSLS']));
 }
 
 if (! empty($_ENV['PMA_SOCKET'])) {
@@ -77,6 +81,9 @@ if (! empty($_ENV['PMA_SOCKET'])) {
 
 /* Server settings */
 for ($i = 1; isset($hosts[$i - 1]); $i++) {
+    if (isset($ssls[$i - 1]) && $ssls[$i - 1] === '1') {
+        $cfg['Servers'][$i]['ssl'] = $ssls[$i - 1];
+    }
     $cfg['Servers'][$i]['host'] = $hosts[$i - 1];
     if (isset($verbose[$i - 1])) {
         $cfg['Servers'][$i]['verbose'] = $verbose[$i - 1];

--- a/fpm/docker-entrypoint.sh
+++ b/fpm/docker-entrypoint.sh
@@ -50,5 +50,7 @@ get_docker_secret PMA_HOST
 get_docker_secret PMA_CONTROLHOST
 get_docker_secret PMA_CONTROLUSER
 get_docker_secret PMA_CONTROLPASS
+get_docker_secret PMA_SSL
+get_docker_secret PMA_SSLS
 
 exec "$@"


### PR DESCRIPTION
enable ssl connection with upstream. no ca used. 
variable introduced: 
`PMA_SSL` for single upstream
`PMA_SSLS` for multiple upstream
`docker run ... -e PMA_HOSTS="mysql-notls,mysql-tls" -e PMA_SSLS="0,1" ...`