### PR TITLE
Fix Dockerfile templates: add helpers.php

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -123,6 +123,7 @@ RUN set -ex; \
 
 # Copy configuration
 COPY config.inc.php /etc/phpmyadmin/config.inc.php
+COPY helpers.php /etc/phpmyadmin/helpers.php
 RUN chown www-data:www-data -R /etc/phpmyadmin/
 
 # Copy main script

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -143,6 +143,7 @@ RUN set -ex; \
 
 # Copy configuration
 COPY config.inc.php /etc/phpmyadmin/config.inc.php
+COPY helpers.php /etc/phpmyadmin/helpers.php
 RUN chown www-data:www-data -R /etc/phpmyadmin/
 
 # Copy main script

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -144,6 +144,7 @@ RUN set -ex; \
 
 # Copy configuration
 COPY config.inc.php /etc/phpmyadmin/config.inc.php
+COPY helpers.php /etc/phpmyadmin/helpers.php
 RUN chown www-data:www-data -R /etc/phpmyadmin/
 
 # Copy main script

--- a/fpm-alpine/Dockerfile
+++ b/fpm-alpine/Dockerfile
@@ -124,6 +124,7 @@ RUN set -ex; \
 
 # Copy configuration
 COPY config.inc.php /etc/phpmyadmin/config.inc.php
+COPY helpers.php /etc/phpmyadmin/helpers.php
 RUN chown www-data:www-data -R /etc/phpmyadmin/
 
 # Copy main script

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -141,6 +141,7 @@ RUN set -ex; \
 
 # Copy configuration
 COPY config.inc.php /etc/phpmyadmin/config.inc.php
+COPY helpers.php /etc/phpmyadmin/helpers.php
 RUN chown www-data:www-data -R /etc/phpmyadmin/
 
 # Copy main script


### PR DESCRIPTION
I have tested the new Dockerfiles and builded multiples images to test the mTLS options,here multiples screens.

I have defined 2 PMA hosts: one without cert and mtls, and the other one with correct configuration. This way I have tested cross configuration files for cross databases auth system (so we can use SSL, mTLS and plain text in the same container).

Firstly, the incorrect configuration:

![image](https://github.com/user-attachments/assets/15975cd9-1abd-480d-8606-a2fb5313cff5)
![image](https://github.com/user-attachments/assets/663dd075-31e3-472a-9db7-1d7f12b26fe5)

We can see that MaxScale, configured with mTLS is denying the first auth request. No new feature here.

Now with the correct configruation:
 
![image](https://github.com/user-attachments/assets/5a0f6e71-e18e-4235-ba4c-416a996a7138)

No error on MaxScale size, certs are accepted by MariaDB and PMA is connected and we get SSL/MariaDB server informations. The new feature is working.

But during tests, I seen that the **helpers.php** was missing in templates and in generated Dockerfiles. So it was not imported during build and base64 vars wans't decoded.

I fixed the problem and now, as far I see, everything is working :)

Tests was done locally, in a Docker SWARM plateform and in K8S. 
